### PR TITLE
Открытие вкладки ранее просмотренной модели и сохранение выбранной вкладки модели на странице /test-drive/ 

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -60,6 +60,7 @@ export const collections = {
             // Идентификаторы и классификация
             mark_id: z.string(),
             folder_id: z.string(),
+            model_id: z.string().optional(),
             color: z.string(),
             // Цены и скидки
             price: z.number(),

--- a/src/js/modules/getModelIdFromReferrer.js
+++ b/src/js/modules/getModelIdFromReferrer.js
@@ -1,0 +1,36 @@
+/**
+ * Функция getModelIdFromReferrer отслеживает откуда пришел пользователь
+ * Извлекает ID модели из пути, если пользователь пришел со страницы модели
+ * Возвращает ID модели или null
+ */
+export function getModelIdFromReferrer(slugToModelId) {
+  const ref = document.referrer || '';
+  
+  if (!ref) {
+    return null;
+  }
+  
+  const { pathname } = new URL(ref, location.href);
+  const searchPaths = ['/models/', '/cars/'];
+  let modelId;
+  
+  const foundPath = searchPaths.find(path => pathname.includes(path));
+  
+  if (!foundPath) {
+    return null;
+  }
+  
+  // Извлекаем model_id из пути /models/
+  if (foundPath === searchPaths[0]) {
+    modelId = pathname.replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
+  }
+  
+  // Извлекаем model_id из пути /cars/ через mapping
+  if (foundPath === searchPaths[1]) {
+    const slug = pathname.split('/').filter(Boolean).pop();
+    const decodedSlug = decodeURIComponent(slug);
+    modelId = slugToModelId[decodedSlug];
+  }
+  
+  return modelId;
+};

--- a/src/js/modules/getModelIdFromReferrer.js
+++ b/src/js/modules/getModelIdFromReferrer.js
@@ -1,36 +1,96 @@
+const STORAGE_KEY = 'test_drive_selected_model';
+
+// Вспомогательная функция для чтения из localStorage
+const getFromStorage = () => {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch (e) {
+    console.warn('Не удалось прочитать выбор модели из localStorage:', e);
+    return null;
+  }
+};
+
+// Вспомогательная функция для сохранения в localStorage
+const saveToStorage = (modelId) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, modelId);
+  } catch (e) {
+    console.warn('Не удалось сохранить выбор модели в localStorage:', e);
+  }
+};
+
 /**
  * Функция getModelIdFromReferrer отслеживает откуда пришел пользователь
  * Извлекает ID модели из пути, если пользователь пришел со страницы модели
+ * Также сохраняет выбор в localStorage и восстанавливает при перезагрузке
  * Возвращает ID модели или null
  */
+
 export function getModelIdFromReferrer(slugToModelId) {
+  // Если пользователь перезагружает текущую страницу, то берем данные из localStorage
+  const navigationEntry = performance.getEntriesByType('navigation')[0];
+  if (navigationEntry && navigationEntry.type === 'reload') {
+    return getFromStorage();
+  }
+
   const ref = document.referrer || '';
   
+  // Если referrer отсутствует - пробуем взять из localStorage
   if (!ref) {
-    return null;
+    return getFromStorage();
   }
   
   const { pathname } = new URL(ref, location.href);
-  const searchPaths = ['/models/', '/cars/'];
-  let modelId;
   
-  const foundPath = searchPaths.find(path => pathname.includes(path));
+  // Пробуем извлечь model_id из путей /models/ или /cars/
+  let modelId = null;
   
-  if (!foundPath) {
-    return null;
+  // Проверяем путь /models/model-name
+  if (pathname.includes('/models/')) {
+    // Извлекаем последний сегмент пути (название модели)
+    const segments = pathname.replace(/\/+$/, '').split('/').filter(Boolean);
+    modelId = segments[segments.length - 1] || null;
   }
   
-  // Извлекаем model_id из пути /models/
-  if (foundPath === searchPaths[0]) {
-    modelId = pathname.replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
+  // Проверяем путь /cars/car-slug
+  if (pathname.includes('/cars/')) {
+    // Извлекаем slug машины из пути
+    const segments = pathname.split('/').filter(Boolean);
+    const slug = segments[segments.length - 1];
+    
+    // Проверяем что slug существует перед декодированием
+    if (slug) {
+      try {
+        const decodedSlug = decodeURIComponent(slug);
+        // Получаем model_id через маппинг slug -> model_id
+        modelId = slugToModelId[decodedSlug] || null;
+      } catch (e) {
+        console.warn('Ошибка декодирования slug:', e);
+      }
+    }
   }
   
-  // Извлекаем model_id из пути /cars/ через mapping
-  if (foundPath === searchPaths[1]) {
-    const slug = pathname.split('/').filter(Boolean).pop();
-    const decodedSlug = decodeURIComponent(slug);
-    modelId = slugToModelId[decodedSlug];
+  // Если нашли model_id - сохраняем в localStorage и возвращаем
+  if (modelId) {
+    saveToStorage(modelId);
+    return modelId;
   }
   
-  return modelId;
-};
+  // Если не нашли model_id из referrer - пробуем взять из localStorage
+  return getFromStorage();
+}
+
+/**
+ * Сохраняет выбранную модель в localStorage
+ * Используется когда пользователь меняет модель вручную на странице
+ */
+export function saveSelectedModel(modelId) {
+  try {
+    if (modelId) {
+      localStorage.setItem(STORAGE_KEY, modelId);
+    }
+  } catch (e) {
+    console.warn('Не удалось сохранить выбор модели в localStorage:', e);
+  }
+}
+

--- a/src/pages/test-drive.astro
+++ b/src/pages/test-drive.astro
@@ -26,8 +26,8 @@ const slugToModelId = Object.fromEntries(
 	window.__slugToModelId = slugToModelId;
 </script>
 <script>
-	import { trackReferrer } from '@/js/modules/trackReferrer.js';
-	const preselectedModelId = trackReferrer(window.__slugToModelId);
+	import { getModelIdFromReferrer } from '@/js/modules/getModelIdFromReferrer.js';
+	const preselectedModelId = getModelIdFromReferrer(window.__slugToModelId);
 	if (preselectedModelId) {
 		window.__preselectedModelId = preselectedModelId;
 	}

--- a/src/pages/test-drive.astro
+++ b/src/pages/test-drive.astro
@@ -26,11 +26,12 @@ const slugToModelId = Object.fromEntries(
 	window.__slugToModelId = slugToModelId;
 </script>
 <script>
-	import { getModelIdFromReferrer } from '@/js/modules/getModelIdFromReferrer.js';
+	import { getModelIdFromReferrer, saveSelectedModel } from '@/js/modules/getModelIdFromReferrer.js';
 	const preselectedModelId = getModelIdFromReferrer(window.__slugToModelId);
 	if (preselectedModelId) {
 		window.__preselectedModelId = preselectedModelId;
 	}
+	window.__saveSelectedModel = saveSelectedModel;
 </script>
 
 <Layout title={`Тест-драйв автомобиля ${brand} – Онлайн запись в салон официального дилера ${brand} в ${legal_city_where}`} description={`Записаться на тест-драйв автомобиля ${brand} в ${legal_city_where} вы можете на официальном сайте дилера ${brand} в ${legal_city_where}, заполнив специальную форму, или по телефонам: ${salonsPhone}`}>
@@ -42,6 +43,9 @@ const slugToModelId = Object.fromEntries(
 		},
 		currentModel: function(id) {
 			this.current = this.models.find(m => m.id === id);
+			if (window.__saveSelectedModel) {
+				window.__saveSelectedModel(id);
+			}
 		},
 		init: function() {
 			this.getModels();

--- a/src/pages/test-drive.astro
+++ b/src/pages/test-drive.astro
@@ -17,6 +17,35 @@ const { testDrive } = modelsData;
 const optionsJSON = JSON.stringify(testDrive);
 ---
 
+<script is:inline>
+	// Логируем источник перехода в консоль.
+	// document.referrer — URL страницы, с которой пользователь пришёл на текущую.
+	// Может быть пустым, если:
+	// - прямой заход (ввёл адрес вручную / закладка)
+	// - сайт-источник или браузер обрезал заголовок из-за Referrer-Policy
+	// - переход из некоторых приложений
+	(function () {
+		const ref = document.referrer || '';
+		let hasModelsInReferrer = false;
+		if (ref) {
+			const { pathname } = new URL(ref, location.href);
+			const searchPath = '/models/';
+			let modelId;
+			hasModelsInReferrer = pathname.includes(searchPath);
+			if (hasModelsInReferrer) {
+				modelId = pathname.replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
+				console.log('model id: ', modelId);
+				// если modelId есть — кладём его глобально, чтобы Alpine смог прочитать
+				if (modelId) window.__preselectedModelId = modelId;
+			}
+			console.log('[test-drive] Пользователь пришёл со страницы:', ref);
+			console.log('[test-drive] referrer содержит "/models/"?', hasModelsInReferrer);
+		} else {
+			console.log('[test-drive] Реферер отсутствует (прямой заход или политика Referrer-Policy)');
+		}
+	})();
+</script>
+
 <Layout title={`Тест-драйв автомобиля ${brand} – Онлайн запись в салон официального дилера ${brand} в ${legal_city_where}`} description={`Записаться на тест-драйв автомобиля ${brand} в ${legal_city_where} вы можете на официальном сайте дилера ${brand} в ${legal_city_where}, заполнив специальную форму, или по телефонам: ${salonsPhone}`}>
 	<div class="flex flex-col lg:flex-row xl:min-h-[600px]" x-data=`{
 		models: null,
@@ -29,6 +58,14 @@ const optionsJSON = JSON.stringify(testDrive);
 		},
 		init: function() {
 			this.getModels();
+			const preId = window.__preselectedModelId;
+			if (preId) {
+				const found = this.models.find(m => m.id === preId);
+				if (found) {
+					this.current = found;
+					return;
+				}
+			}
 			this.currentModel([...this.models][0].id);
 		}
 	}`>

--- a/src/pages/test-drive.astro
+++ b/src/pages/test-drive.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '@/layouts/Layout.astro';
+import { getCollection } from 'astro:content';
 import { AGREE_LABEL } from '@/const';
 import settings from '@/data/settings.json';
 const { brand, legal_city_where } = settings;
@@ -15,31 +16,42 @@ const salonsPhone = salons.map((salon: any) => salon.phone).filter(phone => phon
 import modelsData from '@/data/models.json';
 const { testDrive } = modelsData;
 const optionsJSON = JSON.stringify(testDrive);
+
+const allCars = await getCollection('cars');
+// Получаем объект вида { 'belgee-x70-i-15-amt-177-лс-4wd-style-черный-2025': 'x70'}, чтобы сопоставить потом slug с моделью авто.
+const slugToModelId = Object.fromEntries(
+  allCars.map(car => [car.id, car.data.model_id])
+);
 ---
 
-<script is:inline>
-	// Логируем источник перехода в консоль.
-	// document.referrer — URL страницы, с которой пользователь пришёл на текущую.
-	// Может быть пустым, если:
-	// - прямой заход (ввёл адрес вручную / закладка)
-	// - сайт-источник или браузер обрезал заголовок из-за Referrer-Policy
-	// - переход из некоторых приложений
+<script is:inline define:vars={{ slugToModelId }}>
 	(function () {
 		const ref = document.referrer || '';
-		let hasModelsInReferrer = false;
+		let foundPath;
 		if (ref) {
 			const { pathname } = new URL(ref, location.href);
-			const searchPath = '/models/';
+			const searchPaths = ['/models/', '/cars/'];
 			let modelId;
-			hasModelsInReferrer = pathname.includes(searchPath);
-			if (hasModelsInReferrer) {
-				modelId = pathname.replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
-				console.log('model id: ', modelId);
+			foundPath = searchPaths.find(path => pathname.includes(path));
+			if (foundPath) {
+				console.log('foundPath: ', foundPath);
+				if (foundPath === searchPaths[0]) {
+					modelId = pathname.replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
+					console.log('model id: ', modelId);
+				}
+				if (foundPath === searchPaths[1]) {
+					// Извлекаем slug из URL
+					const slug = pathname.split('/').filter(Boolean).pop();
+					const decodedSlug = decodeURIComponent(slug);
+					// Получаем model_id из mapping
+					modelId = slugToModelId[decodedSlug];
+					console.log('slug:', slug);
+					console.log('model id from /cars/: ', modelId);
+				}
 				// если modelId есть — кладём его глобально, чтобы Alpine смог прочитать
 				if (modelId) window.__preselectedModelId = modelId;
 			}
 			console.log('[test-drive] Пользователь пришёл со страницы:', ref);
-			console.log('[test-drive] referrer содержит "/models/"?', hasModelsInReferrer);
 		} else {
 			console.log('[test-drive] Реферер отсутствует (прямой заход или политика Referrer-Policy)');
 		}

--- a/src/pages/test-drive.astro
+++ b/src/pages/test-drive.astro
@@ -16,46 +16,21 @@ const salonsPhone = salons.map((salon: any) => salon.phone).filter(phone => phon
 import modelsData from '@/data/models.json';
 const { testDrive } = modelsData;
 const optionsJSON = JSON.stringify(testDrive);
-
 const allCars = await getCollection('cars');
-// Получаем объект вида { 'belgee-x70-i-15-amt-177-лс-4wd-style-черный-2025': 'x70'}, чтобы сопоставить потом slug с моделью авто.
 const slugToModelId = Object.fromEntries(
   allCars.map(car => [car.id, car.data.model_id])
 );
 ---
 
 <script is:inline define:vars={{ slugToModelId }}>
-	(function () {
-		const ref = document.referrer || '';
-		let foundPath;
-		if (ref) {
-			const { pathname } = new URL(ref, location.href);
-			const searchPaths = ['/models/', '/cars/'];
-			let modelId;
-			foundPath = searchPaths.find(path => pathname.includes(path));
-			if (foundPath) {
-				console.log('foundPath: ', foundPath);
-				if (foundPath === searchPaths[0]) {
-					modelId = pathname.replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
-					console.log('model id: ', modelId);
-				}
-				if (foundPath === searchPaths[1]) {
-					// Извлекаем slug из URL
-					const slug = pathname.split('/').filter(Boolean).pop();
-					const decodedSlug = decodeURIComponent(slug);
-					// Получаем model_id из mapping
-					modelId = slugToModelId[decodedSlug];
-					console.log('slug:', slug);
-					console.log('model id from /cars/: ', modelId);
-				}
-				// если modelId есть — кладём его глобально, чтобы Alpine смог прочитать
-				if (modelId) window.__preselectedModelId = modelId;
-			}
-			console.log('[test-drive] Пользователь пришёл со страницы:', ref);
-		} else {
-			console.log('[test-drive] Реферер отсутствует (прямой заход или политика Referrer-Policy)');
-		}
-	})();
+	window.__slugToModelId = slugToModelId;
+</script>
+<script>
+	import { trackReferrer } from '@/js/modules/trackReferrer.js';
+	const preselectedModelId = trackReferrer(window.__slugToModelId);
+	if (preselectedModelId) {
+		window.__preselectedModelId = preselectedModelId;
+	}
 </script>
 
 <Layout title={`Тест-драйв автомобиля ${brand} – Онлайн запись в салон официального дилера ${brand} в ${legal_city_where}`} description={`Записаться на тест-драйв автомобиля ${brand} в ${legal_city_where} вы можете на официальном сайте дилера ${brand} в ${legal_city_where}, заполнив специальную форму, или по телефонам: ${salonsPhone}`}>


### PR DESCRIPTION
Задача [https://pyrus.com/t#id310784993](https://pyrus.com/t#id310784993)

## Что сделано

Добавлен механизм автоматического выбора модели на странице `/test-drive` в зависимости от того, откуда пришел пользователь.

### Как работает

**Новый модуль `getModelIdFromReferrer.js`:**

1. **Переход со страницы модели** (`/models/x70plus`)
   - Извлекает ID модели из пути
   - Автоматически выбирает эту модель на странице тест-драйва
   - Сохраняет выбор в localStorage

2. **Переход со страницы автомобиля** (`/cars/jetour-x70-...`)
   - Извлекает slug машины из URL
   - Находит соответствующий model_id через маппинг
   - Выбирает модель и сохраняет в localStorage

3. **Прямой заход или отсутствие referrer**
   - Пытается восстановить последний выбор из localStorage
   - Если данных нет - работает как обычно (выбирается первая модель)

4. **Ручной выбор модели**
   - При смене модели вручную выбор сохраняется в localStorage
   - При следующем посещении восстанавливается

### Файлы

- `src/js/modules/getModelIdFromReferrer.js` - новый модуль с логикой отслеживания
- `src/pages/test-drive.astro` - интеграция модуля на страницу


