### PR TITLE
feat(dev-toolbar): Preserve log + итог ошибок для Domain Switch

### DIFF
--- a/dev-toolbar/domain-switch/app.ts
+++ b/dev-toolbar/domain-switch/app.ts
@@ -6,14 +6,47 @@ type InitPayload = {
   presets: string[];
   currentDomain: string;
   hasJSONPath: boolean;
+  /**
+   * Итог последнего запуска на сервере.
+   *
+   * Зачем:
+   * - UI тулбара может перезагрузиться во время/в конце операции,
+   *   и тогда часть сообщений не успеет дойти до браузера.
+   * - При повторном открытии тулбара мы всё равно покажем,
+   *   были ли ошибки, и какие именно.
+   */
+  lastRun?: {
+    opId: string;
+    ok: boolean;
+    summary: string;
+    errors: string[];
+    finishedAt: string;
+  } | null;
 };
-type StatusPayload = { ok: boolean; message: string; domain?: string };
+type StatusPayload = { ok: boolean; message: string; domain?: string; isFinal?: boolean };
+
+type LogEntry = {
+  ts: number;
+  message: string;
+  /**
+   * null => старая история (когда мы хранили лог как просто текст).
+   * Тогда подсветка невозможна, но мы всё равно показываем строки.
+   */
+  ok: boolean | null;
+  /**
+   * Финальное сообщение по операции:
+   * - ok=true => подсветим зелёным (легче визуально найти конец без ошибок)
+   */
+  isFinal?: boolean;
+};
 
 export default defineToolbarApp({
   init(canvas, app, server) {
     const lsDomainsKey = `${APP_ID}:domains`;
     const lsSelectedKey = `${APP_ID}:selected`;
     const lsLogKey = `${APP_ID}:log`;
+    const lsPreserveLogKey = `${APP_ID}:preserveLog`;
+    const lsLastRunIdKey = `${APP_ID}:lastRunId`;
 
     let domains: string[] = [];
 
@@ -36,19 +69,24 @@ export default defineToolbarApp({
         <style>
           .col{display:flex;flex-direction:column;gap:10px;min-width:360px}
           .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+          .opt{display:flex;align-items:center;gap:8px;font-size:12px;opacity:.85;user-select:none}
+          .opt input{transform: translateY(1px)}
+          .log-line{padding:1px 0}
+          .log-line--err{color:#dc2626}
+          .log-line--final-ok{color:#16a34a}
           /*
             Astro Dev Toolbar окно имеет ограничение по высоте (~480px).
             Если лог "растёт", он начинает выталкивать остальной UI и становится неудобно.
 
-            Поэтому фиксируем высоту области лога и включаем прокрутку.
-            Значение 203px подобрано опытным путём под текущую компоновку.
+            Поэтому фиксируем максимальную высоту области лога и включаем прокрутку.
+            Значение 170px подобрано опытным путём под текущую компоновку.
           */
           .status{
             font-size:12px;
             opacity:.9;
             white-space:pre-wrap;
             overflow-y: scroll;
-            max-height: 203px;
+            max-height: 170px;
           }
           code{font-size:12px}
         </style>
@@ -59,6 +97,8 @@ export default defineToolbarApp({
           </div>
 
           <div class="row" id="domainRow"></div>
+
+          <div class="row" id="options"></div>
 
           <div class="row" id="actions"></div>
 
@@ -73,6 +113,7 @@ export default defineToolbarApp({
       const badge = win.querySelector("#badge") as any;
       const statusEl = win.querySelector("#status") as HTMLDivElement;
       const domainRow = win.querySelector("#domainRow") as HTMLDivElement;
+      const optionsRow = win.querySelector("#options") as HTMLDivElement;
       const actionsRow = win.querySelector("#actions") as HTMLDivElement;
 
       /**
@@ -87,20 +128,68 @@ export default defineToolbarApp({
        * - лог сбрасываем при каждом новом запуске (нажатии кнопки),
        *   чтобы не смешивать разные операции.
        */
-      const renderLogFromLS = () => {
-        statusEl.textContent = localStorage.getItem(lsLogKey) || "";
+      const readLogEntries = (): LogEntry[] => {
+        const raw = localStorage.getItem(lsLogKey) || "";
+        if (!raw) return [];
+
+        // Новый формат: JSON-массив записей (даёт возможность подсветки).
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            return parsed
+              .filter((x) => x && typeof x === "object")
+              .map((x: any) => ({
+                ts: typeof x.ts === "number" ? x.ts : Date.now(),
+                message: String(x.message ?? ""),
+                ok: typeof x.ok === "boolean" ? x.ok : null,
+                isFinal: Boolean(x.isFinal),
+              }))
+              .filter((x) => x.message.trim().length > 0);
+          }
+        } catch {
+          // Старый формат: простой текст.
+        }
+
+        return raw
+          .split("\n")
+          .map((line) => line.trimEnd())
+          .filter(Boolean)
+          .map((message) => ({ ts: Date.now(), message, ok: null }));
+      };
+
+      const writeLogEntries = (entries: LogEntry[]) => {
+        // Защита от бесконечного роста localStorage, если долго пользоваться тулбаром.
+        // 500 строк — обычно с большим запасом для одной операции.
+        const capped = entries.length > 500 ? entries.slice(entries.length - 500) : entries;
+        localStorage.setItem(lsLogKey, JSON.stringify(capped));
+      };
+
+      const renderLog = () => {
+        const entries = readLogEntries();
+        statusEl.innerHTML = "";
+        for (const e of entries) {
+          const div = document.createElement("div");
+          div.className = "log-line";
+          if (e.ok === false) div.classList.add("log-line--err");
+          if (e.isFinal && e.ok === true) div.classList.add("log-line--final-ok");
+          div.textContent = e.message;
+          statusEl.appendChild(div);
+        }
+
+        // UX: если лог длинный — автоматически скроллим к концу.
+        statusEl.scrollTop = statusEl.scrollHeight;
       };
 
       const clearLog = () => {
-        localStorage.setItem(lsLogKey, "");
-        renderLogFromLS();
+        writeLogEntries([]);
+        renderLog();
       };
 
-      const appendLog = (msg: string) => {
-        const prev = localStorage.getItem(lsLogKey) || "";
-        const next = prev ? `${prev}\n${msg}` : msg;
-        localStorage.setItem(lsLogKey, next);
-        renderLogFromLS();
+      const appendLog = (entry: Omit<LogEntry, "ts">) => {
+        const prev = readLogEntries();
+        prev.push({ ts: Date.now(), ...entry });
+        writeLogEntries(prev);
+        renderLog();
       };
 
       const select = document.createElement("astro-dev-toolbar-select") as any;
@@ -112,6 +201,23 @@ export default defineToolbarApp({
 
       domainRow.appendChild(select);
       domainRow.appendChild(addBtn);
+
+      /**
+       * Preserve log:
+       * - ON  => НЕ чистим UI-лог при старте и НЕ просим сервер чистить файл
+       * - OFF => чистим UI-лог при старте и просим сервер стереть файл перед выполнением
+       *
+       * Важно: настройка хранится в localStorage и переживает перезагрузку страницы.
+       */
+      const preserveLabel = document.createElement("label");
+      preserveLabel.className = "opt";
+      preserveLabel.innerHTML = `<input type="checkbox" /> Preserve log`;
+      const preserveCheckbox = preserveLabel.querySelector("input") as HTMLInputElement;
+      preserveCheckbox.checked = localStorage.getItem(lsPreserveLogKey) === "1";
+      preserveCheckbox.addEventListener("change", () => {
+        localStorage.setItem(lsPreserveLogKey, preserveCheckbox.checked ? "1" : "0");
+      });
+      optionsRow.appendChild(preserveLabel);
 
       const makeDownloadButton = (
         label: string,
@@ -125,10 +231,13 @@ export default defineToolbarApp({
         b.addEventListener("click", () => {
           const domain = String(select.element.value || "").trim();
           if (needsDomain && !domain) return setStatus("Выбери домен.", false);
-          // Новый запуск -> новый лог (и новый статус).
-          clearLog();
+          const preserveLog = preserveCheckbox.checked;
+          localStorage.setItem(lsPreserveLogKey, preserveLog ? "1" : "0");
+
+          // Новый запуск -> лог чистим только если Preserve log выключен.
+          if (!preserveLog) clearLog();
           setStatus(`Downloading ${file}…`);
-          server.send(`${APP_ID}:download`, { domain, file });
+          server.send(`${APP_ID}:download`, { domain, file, preserveLog });
         });
         return b;
       };
@@ -205,7 +314,7 @@ export default defineToolbarApp({
       server.on(`${APP_ID}:init`, (data: InitPayload) => {
         loadLS();
         // При открытии панели показываем лог, который мог сохраниться после перезагрузки страницы.
-        renderLogFromLS();
+        renderLog();
         const savedSelected = localStorage.getItem(lsSelectedKey) || "";
         if (Array.isArray(data.presets) && data.presets.length) {
           domains = [...data.presets, ...domains];
@@ -217,9 +326,34 @@ export default defineToolbarApp({
         // Если есть выбранный домен в localStorage, используем его; иначе fallback на currentDomain.
         refreshOptions(savedSelected || data.currentDomain || undefined);
 
+        /**
+         * Показываем итог последнего запуска с сервера, если:
+         * - он есть
+         * - и мы ещё не показывали именно этот opId (чтобы не дублировать при каждом открытии)
+         */
+        if (data.lastRun?.opId) {
+          const shownId = localStorage.getItem(lsLastRunIdKey) || "";
+          if (shownId !== data.lastRun.opId) {
+            appendLog({
+              ok: data.lastRun.ok,
+              isFinal: true,
+              message: `LAST RUN: ${data.lastRun.summary} (${data.lastRun.finishedAt})`,
+            });
+            if (Array.isArray(data.lastRun.errors) && data.lastRun.errors.length) {
+              for (const err of data.lastRun.errors) {
+                appendLog({ ok: false, message: `ERR: ${err}` });
+              }
+            }
+            localStorage.setItem(lsLastRunIdKey, data.lastRun.opId);
+          }
+        }
+
         if (!data.hasJSONPath) {
           setStatus("JSON_PATH не задан на сервере. Добавь JSON_PATH в .env и перезапусти pnpm dev.", false);
-          appendLog("ERR: JSON_PATH не задан на сервере. Добавь JSON_PATH в .env и перезапусти pnpm dev.");
+          appendLog({
+            ok: false,
+            message: "ERR: JSON_PATH не задан на сервере. Добавь JSON_PATH в .env и перезапусти pnpm dev.",
+          });
         } else {
           setStatus("Готово. Выбери домен и нажми Download.", undefined);
           // Не добавляем это в лог, чтобы не засорять историю между реальными операциями.
@@ -228,7 +362,7 @@ export default defineToolbarApp({
 
       server.on(`${APP_ID}:status`, (data: StatusPayload) => {
         setStatus(data.message, data.ok);
-        appendLog(data.message);
+        appendLog({ ok: data.ok, message: data.message, isFinal: Boolean(data.isFinal) });
         if (data.ok && data.domain) {
           localStorage.setItem(lsSelectedKey, data.domain);
         }

--- a/dev-toolbar/domain-switch/integration.ts
+++ b/dev-toolbar/domain-switch/integration.ts
@@ -10,7 +10,7 @@ const APP_ID = "domain-switch";
 const exec = promisify(execCb);
 
 type HelloPayload = Record<string, never>;
-type DownloadPayload = { domain: string; file?: string };
+type DownloadPayload = { domain: string; file?: string; preserveLog?: boolean };
 
 const domainFiles = [
   "settings.json",
@@ -67,6 +67,24 @@ export default function domainSwitchToolbar(): AstroIntegration {
         const jsonPath = getEnvVar("JSON_PATH").replace(/\/$/, "");
 
         /**
+         * Сводка последнего запуска.
+         *
+         * Зачем:
+         * - UI тулбара может перезагрузиться в конце операции и не получить финальные статусы.
+         * - При следующем открытии тулбара мы отдаём итоги последней операции, чтобы 100% понять:
+         *   были ли ошибки или нет.
+         */
+        let lastRun:
+          | {
+              opId: string;
+              ok: boolean;
+              summary: string;
+              errors: string[];
+              finishedAt: string;
+            }
+          | null = null;
+
+        /**
          * Серверный лог в файл (на стороне Node.js).
          *
          * Зачем:
@@ -86,13 +104,31 @@ export default function domainSwitchToolbar(): AstroIntegration {
           getEnvVar("DOMAIN_SWITCH_LOG_FILE") ||
           path.join(process.cwd(), "tmp", "dev-toolbar", "domain-switch.log");
 
-        const appendServerLog = async (level: "INFO" | "WARN", message: string) => {
+        const appendServerLog = async (level: "INFO" | "WARN", message: string, opId?: string) => {
           try {
             await fs.mkdir(path.dirname(logFilePath), { recursive: true });
-            const line = `[${new Date().toISOString()}] [${APP_ID}] [${level}] ${message}\n`;
+            const opPart = opId ? ` [OP:${opId}]` : "";
+            const line = `[${new Date().toISOString()}] [${APP_ID}] [${level}]${opPart} ${message}\n`;
             await fs.appendFile(logFilePath, line, "utf8");
           } catch {
             // best-effort: не мешаем основному процессу
+          }
+        };
+
+        /**
+         * Очистка серверного log-файла.
+         *
+         * Почему именно тут:
+         * - пользователь просит "гарантировать" отсутствие ошибок.
+         * - если preserveLog выключен, то проще всего начинать с чистого файла
+         *   и писать туда только текущий запуск.
+         */
+        const truncateServerLog = async () => {
+          try {
+            await fs.mkdir(path.dirname(logFilePath), { recursive: true });
+            await fs.writeFile(logFilePath, "", "utf8");
+          } catch {
+            // best-effort
           }
         };
 
@@ -104,14 +140,17 @@ export default function domainSwitchToolbar(): AstroIntegration {
          *
          * Так мы НЕ теряем сообщения, даже если UI перезагрузился.
          */
-        const report = async (data: { ok: boolean; message: string; domain?: string }) => {
+        const report = async (
+          data: { ok: boolean; message: string; domain?: string; isFinal?: boolean },
+          opId?: string
+        ) => {
           toolbar.send(`${APP_ID}:status`, data);
           if (data.ok) {
             logger.info(`[${APP_ID}] ${data.message}`);
-            await appendServerLog("INFO", data.message);
+            await appendServerLog("INFO", data.message, opId);
           } else {
             logger.warn(`[${APP_ID}] ${data.message}`);
-            await appendServerLog("WARN", data.message);
+            await appendServerLog("WARN", data.message, opId);
           }
         };
 
@@ -121,32 +160,45 @@ export default function domainSwitchToolbar(): AstroIntegration {
             presets,
             currentDomain: currentDomain ?? "",
             hasJSONPath: Boolean(jsonPath),
+            lastRun,
           });
         });
 
-        const runScript = async (cmd: string, label: string) => {
+        const runScript = async (
+          cmd: string,
+          label: string,
+          opId?: string,
+          onError?: (message: string) => void
+        ) => {
           try {
-            await report({ ok: true, message: `RUN: ${label}` });
+            await report({ ok: true, message: `RUN: ${label}` }, opId);
             const { stdout, stderr } = await exec(cmd, { cwd: process.cwd() });
             if (stdout?.trim()) logger.info(`[${APP_ID}] ${label}: ${stdout.trim()}`);
             if (stderr?.trim()) logger.warn(`[${APP_ID}] ${label} stderr: ${stderr.trim()}`);
-            await appendServerLog("INFO", `DONE: ${label}`);
-            toolbar.send(`${APP_ID}:status`, { ok: true, message: label });
+            await appendServerLog("INFO", `DONE: ${label}`, opId);
+            await report({ ok: true, message: label }, opId);
             return true;
           } catch (err: any) {
             const msg = `${label} error: ${err?.message ?? err}`;
             logger.warn(`[${APP_ID}] ${msg}`);
-            await appendServerLog("WARN", msg);
-            toolbar.send(`${APP_ID}:status`, { ok: false, message: msg });
+            await appendServerLog("WARN", msg, opId);
+            await report({ ok: false, message: msg }, opId);
+            // Важно: добавляем в список ошибок текущей операции (для финального вердикта).
+            onError?.(msg);
             return false;
           }
         };
 
-        const downloadDomainFile = async (safeDomain: string, targetFile: string) => {
+        const downloadDomainFile = async (
+          safeDomain: string,
+          targetFile: string,
+          opId?: string,
+          onError?: (message: string) => void
+        ) => {
           const url = `${jsonPath}/${safeDomain}/data/${targetFile}`;
           const dest = path.join(process.cwd(), "src", "data", targetFile);
 
-          await report({ ok: true, message: `START: скачиваю ${targetFile} с домена ${safeDomain}` });
+          await report({ ok: true, message: `START: скачиваю ${targetFile} с домена ${safeDomain}` }, opId);
           const res = await fetch(url);
           if (!res.ok) throw new Error(`HTTP ${res.status} при скачивании: ${url}`);
 
@@ -159,24 +211,85 @@ export default function domainSwitchToolbar(): AstroIntegration {
             ok: true,
             message: `OK: скачал ${targetFile} (${buf.length} bytes) с домена ${safeDomain}`,
             domain: safeDomain,
-          });
+          }, opId);
 
           if (targetFile === "settings.json") {
-            await runScript("node .github/scripts/setBrand.mjs", "Обновил данные бренда (setBrand.mjs)");
-            await runScript("node .github/scripts/filterModelsByBrand.js", "Обновил модели (filterModelsByBrand)");
+            await runScript(
+              "node .github/scripts/setBrand.mjs",
+              "Обновил данные бренда (setBrand.mjs)",
+              opId,
+              onError
+            );
+            await runScript(
+              "node .github/scripts/filterModelsByBrand.js",
+              "Обновил модели (filterModelsByBrand)",
+              opId,
+              onError
+            );
           }
           if (targetFile === "banners.json") {
             await runScript(
               "node .github/scripts/replacePlaceholdersAndSearchDates.js",
-              "Обновил баннеры (replacePlaceholdersAndSearchDates.js)"
+              "Обновил баннеры (replacePlaceholdersAndSearchDates.js)",
+              opId,
+              onError
             );
           }
         };
 
         // Команда скачать файл/файлы
-        toolbar.on<DownloadPayload>(`${APP_ID}:download`, async ({ domain, file }) => {
+        toolbar.on<DownloadPayload>(`${APP_ID}:download`, async ({ domain, file, preserveLog }) => {
           const targetFile = file || "settings.json";
           const safeDomain = String(domain || "").trim();
+          const preserve = Boolean(preserveLog);
+
+          /**
+           * ID операции нужен, чтобы:
+           * - пометить записи в log-файле
+           * - сохранить lastRun и показать итоги после перезагрузки UI
+           */
+          const opId = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 6)}`;
+
+          // Ошибки собираем в массив. Это и есть наш "100% вердикт".
+          // Всё, что мы считаем ошибкой, отправляем через report({ok:false,...}),
+          // а значит попадает и в UI, и в файл, и в lastRun.
+          const errors: string[] = [];
+          const reportRun = async (data: { ok: boolean; message: string; domain?: string; isFinal?: boolean }) => {
+            if (data.ok === false) errors.push(data.message);
+            await report(data, opId);
+          };
+
+          const finalizeRun = async (summary: string) => {
+            const ok = errors.length === 0;
+            lastRun = {
+              opId,
+              ok,
+              summary,
+              errors,
+              finishedAt: new Date().toISOString(),
+            };
+
+            if (!ok) {
+              // Отдельно дублим ошибки в UI в конце, чтобы их было проще заметить
+              // даже если часть сообщений "потерялась" из-за перезагрузки UI.
+              for (const err of errors) {
+                await report({ ok: false, message: `ERR: ${err}` }, opId);
+              }
+              await reportRun({ ok: false, message: `FINISH: ${summary} (ошибок: ${errors.length})`, isFinal: true });
+            } else {
+              await reportRun({ ok: true, message: `FINISH: ${summary} (без ошибок)`, isFinal: true });
+            }
+          };
+
+          // Управляем файлом лога в зависимости от Preserve log.
+          if (!preserve) {
+            await truncateServerLog();
+            await appendServerLog("INFO", "TRUNCATE: preserveLog выключен -> очищаю log-файл перед запуском", opId);
+          } else {
+            await appendServerLog("INFO", "PRESERVE: preserveLog включен -> log-файл НЕ очищаю", opId);
+          }
+
+          await appendServerLog("INFO", `OP_START: file=${targetFile} domain=${safeDomain || "-"} preserveLog=${preserve}`, opId);
 
           const isCommonModels = targetFile === "__common_models__";
           const isCommonCars = targetFile === "__common_cars__";
@@ -184,55 +297,80 @@ export default function domainSwitchToolbar(): AstroIntegration {
 
           // Общие файлы, не зависящие от домена
           if (isCommonModels) {
-            await appendServerLog("INFO", "START: скачиваю общий models");
-            await runScript("bash ./.github/scripts/sh/downloadCommonModelsJSON.sh", "Скачал общий models");
+            try {
+              await reportRun({ ok: true, message: "START: скачиваю общий models" });
+              await runScript(
+                "bash ./.github/scripts/sh/downloadCommonModelsJSON.sh",
+                "Скачал общий models",
+                opId,
+                (msg) => errors.push(msg)
+              );
+            } catch (e: any) {
+              await reportRun({ ok: false, message: e?.message ?? String(e) });
+            } finally {
+              await appendServerLog("INFO", "OP_END", opId);
+              await finalizeRun("Общий models");
+            }
             return;
           }
           if (isCommonCars) {
-            await appendServerLog("INFO", "START: скачиваю общий cars");
-            await runScript("bash ./.github/scripts/sh/downloadCommonCarsJSON.sh", "Скачал общий cars");
+            try {
+              await reportRun({ ok: true, message: "START: скачиваю общий cars" });
+              await runScript(
+                "bash ./.github/scripts/sh/downloadCommonCarsJSON.sh",
+                "Скачал общий cars",
+                opId,
+                (msg) => errors.push(msg)
+              );
+            } catch (e: any) {
+              await reportRun({ ok: false, message: e?.message ?? String(e) });
+            } finally {
+              await appendServerLog("INFO", "OP_END", opId);
+              await finalizeRun("Общий cars");
+            }
             return;
           }
 
           // Всё остальное требует jsonPath и домен
           if (!jsonPath) {
-            await report({
+            await reportRun({
               ok: false,
               message: "JSON_PATH пустой. Укажи JSON_PATH в .env и перезапусти pnpm dev.",
             });
+            await appendServerLog("INFO", "OP_END", opId);
+            await finalizeRun("Ошибка конфигурации JSON_PATH");
             return;
           }
           if (!safeDomain) {
-            await report({ ok: false, message: "Домен не выбран." });
+            await reportRun({ ok: false, message: "Домен не выбран." });
+            await appendServerLog("INFO", "OP_END", opId);
+            await finalizeRun("Ошибка: домен не выбран");
             return;
           }
 
           const filesToDownload = isDownloadAll ? domainFiles : [targetFile];
 
           try {
-            await report({
+            await reportRun({
               ok: true,
               message: `START: скачивание (${filesToDownload.length} шт.) для домена ${safeDomain}`,
               domain: safeDomain,
             });
             for (const f of filesToDownload) {
-              await downloadDomainFile(safeDomain, f);
+              await downloadDomainFile(safeDomain, f, opId, (msg) => errors.push(msg));
             }
             if (isDownloadAll) {
-              await report({
-                ok: true,
-                message: `OK: скачал ${filesToDownload.length} файлов для ${safeDomain}`,
-                domain: safeDomain,
-              });
+              await reportRun({ ok: true, message: `OK: скачал ${filesToDownload.length} файлов для ${safeDomain}`, domain: safeDomain });
             }
+            await appendServerLog("INFO", "OP_END", opId);
+            await finalizeRun(isDownloadAll ? `Скачал все файлы для ${safeDomain}` : `Скачал ${targetFile} для ${safeDomain}`);
           } catch (e: any) {
             const msg = e?.message ?? String(e);
             logger.warn(`[${APP_ID}] ${msg}`);
-            await appendServerLog("WARN", msg);
-            await report({
-              ok: false,
-              message: msg,
-            });
+            await appendServerLog("WARN", msg, opId);
+            await reportRun({ ok: false, message: msg });
+            await appendServerLog("INFO", "OP_END", opId);
+            await finalizeRun(isDownloadAll ? `Скачивание всех файлов для ${safeDomain}` : `Скачивание ${targetFile} для ${safeDomain}`);
           }
         });
       },


### PR DESCRIPTION
**Что сделано**
- **Добавлен чекбокс “Preserve log”** в Dev Toolbar (Domain switch):
  - при выключенном — UI-лог очищается на старте, а серверный `tmp/dev-toolbar/domain-switch.log` **очищается** перед запуском
  - при включенном — логи **сохраняются** (append)
- **UI-лог стал структурированным** (хранится в `localStorage` как список записей), добавлена:
  - **подсветка ошибок красным**
  - **подсветка финального успешного статуса зелёным**
  - ограничение высоты области лога + скролл (под лимит окна тулбара)
- На сервере добавлено:
  - **сбор ошибок “за операцию”** и финальный статус `FINISH` с `isFinal`
  - **lastRun** (итог последнего запуска), чтобы UI мог показать результат даже после перезагрузки тулбара

**Зачем**
- Чтобы **ошибки не терялись** при перезагрузках во время скачивания/скриптов и их было **легко увидеть** в интерфейсе.
- Чтобы был **гарантированный итог** операции (успех/ошибки) и его можно было посмотреть после перезапуска UI.

**Как проверить**
- `pnpm dev` → открыть Dev Toolbar → **Domain**.
- Выключить/включить **Preserve log**, нажать “Скачать всё”.
- Проверить:
  - ошибки подсвечиваются **красным**, финальный успех — **зелёным**
  - при Preserve OFF файл `tmp/dev-toolbar/domain-switch.log` начинается “с чистого листа”
  - после перезагрузки страницы/тулбара отображается `LAST RUN: ...` с итогом/ошибками

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness and observability of Domain switch operations.
> 
> - UI: adds `Preserve log` option (stored in `localStorage`), structured log storage/rendering with error/finish highlighting, capped height with scroll, and auto-append of server messages
> - Protocol: extends `status` with `isFinal` and `init` with `lastRun`; download messages now include START/OK/FINISH entries
> - Server: introduces file-based logging at `tmp/dev-toolbar/domain-switch.log` (overridable via `DOMAIN_SWITCH_LOG_FILE`), with `preserveLog` controlling truncate/append; unifies reporting to UI/console/file via `report()` and tags entries with `opId`
> - Reliability: aggregates per-operation errors, emits final `FINISH` verdict, and exposes `lastRun` so UI can display results after reload; ensures domain selection persistence and handles common downloads (`__common_models__`, `__common_cars__`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae0a419a8b03092fee783fbbb2046ca7456affb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->