### PR TITLE
Fix banner padding for transparent header mode

### DIFF
--- a/src/components/Banner/Banner.astro
+++ b/src/components/Banner/Banner.astro
@@ -10,7 +10,7 @@ const { banners = bannersData } = Astro.props;
 import settings from '@/data/settings.json';
 const { is_header_transparent } = settings;
 
-const bannerClasses = is_header_transparent ? 'pb-[177.78%] md:pb-[100%] lg:pb-[56.25%]' : 'pb-[135%] md:pb-[100%] lg:pb-[56.25%] 2xl:pb-[40%]';
+const bannerClasses = is_header_transparent ? 'pb-[160%] md:pb-[100%] lg:pb-0 lg:min-h-[850px] lg:h-dvh' : 'pb-[135%] md:pb-[100%] lg:pb-[56.25%] 2xl:pb-[40%]';
 ---
 
 {

--- a/src/components/Banner/BannerSlide.astro
+++ b/src/components/Banner/BannerSlide.astro
@@ -13,9 +13,12 @@ import BannerVideo from './Video.astro';
 import BannerImage from './Image.astro';
 
 import settings from '@/data/settings.json';
-const { is_header_transparent } = settings;
+const { is_header_transparent, header_top_line } = settings;
 
-const containerClasses = is_header_transparent ? 'px-5 md:px-18 pb-5 pt-[100px] sm:pt-[125px] md:pt-[150px] lg:pt-[200px]' : 'px-5 sm:px-10 md:px-18 pt-5 pb-5 sm:pt-10 lg:py-20';
+const containerClasses = is_header_transparent 
+	? 'pt-[80px] md:pt-[100px] lg:pt-[149px]' 
+	: is_header_transparent && header_top_line ? 'pt-[117px] md:pt-[141px] lg:pt-[190px]'
+	: 'pt-5 sm:pt-10 lg:py-10';
 
 // Определяем цвет кнопки с fallback на белый
 const btnColor = banner?.btnColor ? banner?.btnColor : 'white';
@@ -39,7 +42,7 @@ const linkAttrs = hasBannerUrl ? {
 ---
 
 <div class={`swiper-slide banner-slide ${banner?.gradient === false ? '' : 'gradient'}`} data-swiper-autoplay={banner?.autoplay ? banner.autoplay : 5000}>
-	<div class={`h-full relative z-2 ${containerClasses}`}>
+	<div class={`h-full relative z-2 px-5 sm:px-10 md:px-20 pb-5 banner-slide-container ${containerClasses}`}>
 		<div class="h-full flex flex-col justify-between">
 			<div class="">
 				{ banner?.title && ( <BannerTitle title={banner.title} /> ) }

--- a/src/components/Banner/BannerSlide.astro
+++ b/src/components/Banner/BannerSlide.astro
@@ -15,9 +15,10 @@ import BannerImage from './Image.astro';
 import settings from '@/data/settings.json';
 const { is_header_transparent, header_top_line } = settings;
 
-const containerClasses = is_header_transparent 
-	? 'pt-[80px] md:pt-[100px] lg:pt-[149px]' 
-	: is_header_transparent && header_top_line ? 'pt-[117px] md:pt-[141px] lg:pt-[190px]'
+const containerClasses = is_header_transparent && header_top_line
+	? 'pt-[117px] md:pt-[141px] lg:pt-[190px]'
+	: is_header_transparent
+	? 'pt-[80px] md:pt-[100px] lg:pt-[149px]'
 	: 'pt-5 sm:pt-10 lg:py-10';
 
 // Определяем цвет кнопки с fallback на белый

--- a/src/components/Banner/banner.js
+++ b/src/components/Banner/banner.js
@@ -1,6 +1,9 @@
 import Swiper from "swiper";
 import { Navigation, Pagination, Autoplay, Parallax, Keyboard } from "swiper/modules";
 
+import settings from '@/data/settings.json';
+const { is_header_transparent } = settings;
+
 const progressCircle = document.querySelector(".autoplay-progress svg");
 const progressContent = document.querySelector(".autoplay-progress span");
 let bannerSlider;
@@ -17,6 +20,29 @@ if (progressCircle) {
 }
 
 const slides = document.querySelectorAll(".banner-slide");
+
+const headerEl = document.querySelector('.header-wrapper');
+const closeHeaderTopLineBtn = document.querySelector('.close-header-top-line-btn');
+function setPaddingTop(){
+	const headerElHeight = headerEl.clientHeight;
+	Array.from(slides).map(s => {
+		const container = s.querySelector('.banner-slide-container');
+		container.style.paddingTop = `${headerElHeight+20}px`;
+	});
+}
+document.addEventListener('alpine:init', () => {
+	setTimeout(() => {	
+		if(slides.length > 0 && is_header_transparent){
+			setPaddingTop();
+			window.addEventListener('resize', setPaddingTop);
+			if(closeHeaderTopLineBtn){				
+				closeHeaderTopLineBtn.addEventListener('click', () => {
+					setTimeout(setPaddingTop, 0);
+				});
+			}
+		}	
+	}, 0);
+});
 
 const initSlider = () => {
 	bannerSlider = new Swiper(".banner-slider", {

--- a/src/components/Banner/banner.js
+++ b/src/components/Banner/banner.js
@@ -24,6 +24,7 @@ const slides = document.querySelectorAll(".banner-slide");
 const headerEl = document.querySelector('.header-wrapper');
 const closeHeaderTopLineBtn = document.querySelector('.close-header-top-line-btn');
 function setPaddingTop(){
+	if(!headerEl) return;
 	const headerElHeight = headerEl.clientHeight;
 	Array.from(slides).map(s => {
 		const container = s.querySelector('.banner-slide-container');
@@ -37,7 +38,7 @@ document.addEventListener('alpine:init', () => {
 			window.addEventListener('resize', setPaddingTop);
 			if(closeHeaderTopLineBtn){				
 				closeHeaderTopLineBtn.addEventListener('click', () => {
-					setTimeout(setPaddingTop, 0);
+					requestAnimationFrame(setPaddingTop);
 				});
 			}
 		}	

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -34,7 +34,7 @@ const borderColor = is_header_transparent ? 'border-header-border-transparent' :
 ---
 <div
 	x-data="header"
-	class={`${headerGlobalClasses} ${headerBgClasses} ${colorText} w-full top-0 left-0 transition-all duration-300 z-50`}
+	class={`${headerGlobalClasses} ${headerBgClasses} ${colorText} w-full top-0 left-0 transition-all duration-300 z-50 header-wrapper`}
 	:class="{'shadow-3xl': scrolling}"
 >
 	<header>

--- a/src/components/Header/HeaderTopLine.astro
+++ b/src/components/Header/HeaderTopLine.astro
@@ -15,7 +15,7 @@ const {content, classes = is_header_transparent ? defaultClasses : 'bg-accent-50
 		<Fragment set:html={content}>
 		{closeBtn && (
 			<button 
-				class="text-base absolute h-8 sm:h-full w-8 sm:w-10 right-0 top-0 z-10"
+				class="text-base absolute h-8 sm:h-full w-8 sm:w-10 right-0 top-0 z-10 close-header-top-line-btn"
 				@click="hideTopLine"
 			>
 				<Icon name="mdi:close" class="text-lg text-white/80 hover:text-white transition-colors" />


### PR DESCRIPTION
- Динамический расчёт padding-top баннерных слайдов на основе реальной высоты хедера (вместо захардкоженных CSS-значений)
- Пересчёт отступа при ресайзе окна и при закрытии верхней информационной строки хедера
- Обновлены CSS-классы баннера для корректного отображения в режиме прозрачного хедера (full-height на десктопе)
- Добавлены служебные CSS-классы (header-wrapper, close-header-top-line-btn, banner-slide-container) для JS-селекторов

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new runtime DOM measurements and resize/click listeners that can affect banner layout and performance across breakpoints, but is scoped to the banner/header UI.
> 
> **Overview**
> Fixes banner content overlap in *transparent header* mode by switching from hardcoded top paddings to a JS-driven padding based on the actual `.header-wrapper` height, recalculated on window resize and when the header top-line is closed.
> 
> Adjusts banner/slide layout classes for transparent headers (desktop full-height behavior) and adds helper classes (`header-wrapper`, `banner-slide-container`, `close-header-top-line-btn`) to support the new selectors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70bbf5f0070e9bf71dc3b2767ff848ae859c2a24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->