### PR TITLE
Add SiteNavigationElement JSON-LD from LINKS_MENU

### DIFF
--- a/src/components/SchemaOrg/Index.astro
+++ b/src/components/SchemaOrg/Index.astro
@@ -1,5 +1,7 @@
 ---
 import type { TBreadcrumb } from '@/components/Breadcrumbs/types';
+import { LINKS_MENU } from '@/const.js';
+
 interface Props {
   breadcrumbs?: TBreadcrumb[];
 }
@@ -20,6 +22,7 @@ const raw = schema[currentPath];
 const schemas = raw ? (Array.isArray(raw) ? raw : [raw]) : [];
 
 const siteUrl = Astro.site?.href.replace(/\/$/, '') ?? '';
+
 const breadcrumbListSchema = breadcrumbs && breadcrumbs.length > 0 && schemas.length > 0
   ? {
       "@context": "https://schema.org",
@@ -36,7 +39,57 @@ const breadcrumbListSchema = breadcrumbs && breadcrumbs.length > 0 && schemas.le
     }
   : null;
 
-const allSchemas = [...schemas, ...(breadcrumbListSchema ? [breadcrumbListSchema] : [])];
+const isValidUrl = (url: unknown): url is string =>
+  typeof url === 'string' &&
+  !url.startsWith('/#') &&
+  !url.startsWith('javascript:');
+
+const flatNavLinks: { name: string; url: string }[] = [];
+const pushNavLink = (name: unknown, url: unknown) => {
+  if (typeof name === 'string' && isValidUrl(url)) {
+    flatNavLinks.push({ name, url: siteUrl + url });
+  }
+};
+
+for (const link of LINKS_MENU as any[]) {
+  pushNavLink(link?.name, link?.url);
+
+  if (Array.isArray(link.children)) {
+    for (const child of link.children) {
+      pushNavLink(child?.name, child?.url);
+    }
+  } else if (link.children && typeof link.children === 'object') {
+    for (const brandItems of Object.values(link.children as Record<string, unknown>)) {
+      if (!Array.isArray(brandItems)) continue;
+
+      for (const child of brandItems) {
+        pushNavLink((child as { name?: unknown })?.name, (child as { url?: unknown })?.url);
+      }
+    }
+  }
+}
+
+const navItems = flatNavLinks.map((link, i) => ({
+  "@type": "SiteNavigationElement",
+  "position": i + 1,
+  "name": link.name,
+  "url": link.url,
+}));
+
+const navSchema = navItems.length > 0
+  ? {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "name": "Главное меню",
+      "itemListElement": navItems,
+    }
+  : null;
+
+const allSchemas = [
+  ...schemas,
+  ...(breadcrumbListSchema ? [breadcrumbListSchema] : []),
+  ...(navSchema ? [navSchema] : []),
+];
 ---
 
 {allSchemas.length > 0 && (

--- a/src/components/SchemaOrg/Index.astro
+++ b/src/components/SchemaOrg/Index.astro
@@ -76,7 +76,7 @@ const navItems = flatNavLinks.map((link, i) => ({
   "url": link.url,
 }));
 
-const navSchema = navItems.length > 0
+const navSchema = navItems.length > 0 && schemas.length > 0
   ? {
       "@context": "https://schema.org",
       "@type": "ItemList",


### PR DESCRIPTION
## Summary                                                                                                                                       
- Generates a `SiteNavigationElement` (ItemList) JSON-LD block from `LINKS_MENU`, traversing both array- and object-shaped `children` (brand     
groups).                                                                                                                                         
- Filters out anchor (`/#…`) and `javascript:` URLs, prefixes the rest with `Astro.site`.                                                        
- Renders only on pages that already have a `schema.json` entry — consistent with how breadcrumbs are gated, so sites without configured schemas 
stay clean.                                                                                                                                      
                                                                                                                                                 
## Test plan                                                                                                                                     
- [x] Page with `schema.json` entry → JSON-LD includes page schema, breadcrumbs, and nav schema.                                                 
- [ ] Page without entry → no `<script type="application/ld+json">` rendered.                                   
- [x] No `schema.json` file at all → build succeeds, nothing rendered.                                                                           
- [ ] Validate output in Google Rich Results Test on a representative page.