### PR TITLE
Add dwell-time beacon + fix mobile analytics triggers

### DIFF
--- a/src/components/Scripts/Head.astro
+++ b/src/components/Scripts/Head.astro
@@ -23,6 +23,7 @@ import STREAMWOOD from '@/components/Scripts/components/runSTREAMWOOD.astro';
 import SMARTPOINT from '@/components/Scripts/components/runSMARTPOINT.astro';
 import WIDGETS from '@/components/Scripts/components/runWIDGETS.astro';
 import LoadAnalyticsScripts from '@/components/Scripts/components/loadAnalyticsScripts.astro';
+import DWELL from '@/components/Scripts/components/runDWELL.astro';
 
 const cleanedScripts = cleanScriptsData(scripts_json);
 ---
@@ -40,4 +41,5 @@ const cleanedScripts = cleanScriptsData(scripts_json);
 <STREAMWOOD />
 <SMARTPOINT />
 <WIDGETS />
+<DWELL />
 <LoadAnalyticsScripts />

--- a/src/components/Scripts/components/loadAnalyticsScripts.astro
+++ b/src/components/Scripts/components/loadAnalyticsScripts.astro
@@ -58,10 +58,17 @@
             loadAnalyticsScripts();
             return;
         }
-        
-        // Otherwise, set up event listeners
-        window.addEventListener('scroll', loadAnalyticsScripts);
-        document.addEventListener('mousemove', loadAnalyticsScripts);
+
+        // Триггеры запуска аналитики при первом взаимодействии.
+        // touchstart/pointerdown/keydown — для мобильных: mousemove на тачскрине не существует,
+        // из-за чего короткие визиты без скролла раньше не попадали в Метрику.
+        ['scroll','mousemove','touchstart','pointerdown','keydown'].forEach(function(ev){
+            var tgt = (ev === 'scroll') ? window : document;
+            tgt.addEventListener(ev, loadAnalyticsScripts, { once: true, passive: true });
+        });
+        // Страховка: если за 3 сек не было ни одного взаимодействия — всё равно грузим аналитику.
+        // Ловит «открыл, посмотрел, закрыл, ничего не трогая» — типичный мобильный визит из ПромоСтраниц.
+        setTimeout(loadAnalyticsScripts, 3000);
     }
 
     // Initialize based on document ready state

--- a/src/components/Scripts/components/runDWELL.astro
+++ b/src/components/Scripts/components/runDWELL.astro
@@ -1,0 +1,35 @@
+---
+// First-party маячок времени на странице.
+// Шлёт navigator.sendBeacon на /__t.gif при закрытии вкладки/уходе со страницы.
+// Эндпоинт обрабатывается nginx прямо на сервере (return 204), не зависит от Метрики/GHP.
+// Лог попадает в /var/log/nginx/access.log на 88.218.61.141 — оттуда считаем dwell-time.
+const isProd = import.meta.env.PROD;
+---
+{isProd && (
+<script>
+(function(){
+  if (typeof navigator === 'undefined' || !('sendBeacon' in navigator)) return;
+  var t0 = performance.now();
+  var sent = false;
+  function send(){
+    if (sent) return; sent = true;
+    var t = Math.max(0, Math.round((performance.now() - t0) / 1000));
+    try {
+      var url = '/__t.gif?p=' + encodeURIComponent(location.pathname)
+              + '&q=' + encodeURIComponent(location.search.slice(0, 500))
+              + '&r=' + encodeURIComponent((document.referrer || '').slice(0, 300))
+              + '&t=' + t
+              + '&s=' + (screen.width + 'x' + screen.height)
+              + '&v=1';
+      navigator.sendBeacon(url);
+    } catch (e) {}
+  }
+  // pagehide — единственное надёжное событие в Safari/iOS (unload там не срабатывает).
+  // visibilitychange ловит сворачивание вкладки и переход в фон на мобильных.
+  window.addEventListener('pagehide', send, { capture: true });
+  document.addEventListener('visibilitychange', function(){
+    if (document.visibilityState === 'hidden') send();
+  });
+})();
+</script>
+)}


### PR DESCRIPTION
Две независимые правки против потери ~50% хитов Метрики на мобильном трафике (в основном Яндекс.ПромоСтраницы):

1. loadAnalyticsScripts.astro — расширены триггеры запуска аналитики: добавлены touchstart/pointerdown/keydown (mousemove на тачскрине не существует)
   + setTimeout(loadAnalyticsScripts, 3000) — страховка для коротких визитов без взаимодействия.

2. runDWELL.astro — новый компонент. Шлёт navigator.sendBeacon('/__t.gif?p=…&t=…') на pagehide и visibilitychange:hidden. Эндпоинт /__t.gif обрабатывается nginx на 88.218.61.141 (return 204, snippet dwell-beacon.conf), пишется в access.log с реальным временем на странице — независимо от того, успела загрузиться Метрика или нет. Подробности и формат лога — VDS/88.218.61.141-sites/REPORT-dwell-beacon-2026-05-20.md.

Head.astro — подключение <DWELL /> перед <LoadAnalyticsScripts />.