### PR TITLE
feat(manuals): плитки руководств ManualMediaCard + ManualFileCard

### DIFF
--- a/src/blocks/manuals/ManualFileCard.astro
+++ b/src/blocks/manuals/ManualFileCard.astro
@@ -1,0 +1,42 @@
+---
+// Плитка руководства как PDF-карточка (вариант дилеров Penza/Orenburg).
+import Button from '@/ui/button/Button.astro';
+import { Icon } from 'astro-icon/components';
+
+interface Props {
+	name: string;
+	url: string;
+	format?: string;
+	size?: string;
+}
+const { name, url, format = 'PDF', size } = Astro.props;
+---
+<div class="flex flex-col rounded-2xl border border-gray-200 bg-white shadow-sm hover:shadow-md transition-shadow overflow-hidden">
+	<div class="flex items-center gap-4 bg-gray-50 border-b border-gray-200 px-5 py-4">
+		<Icon name="mdi:file-pdf-box" class="text-red-500 shrink-0 text-5xl" />
+		<div>
+			<p class="text-xs text-gray-400 uppercase tracking-wide font-medium mb-0.5">Руководство по эксплуатации</p>
+			<h2 class="m-0! p-0! before:hidden text-lg! font-semibold leading-tight">{name}</h2>
+		</div>
+	</div>
+	{(format || size) && (
+		<div class="flex items-center gap-3 px-5 py-3 text-sm text-gray-500">
+			{format && (
+				<span class="inline-flex items-center gap-1">
+					<Icon name="mdi:tag-outline" class="text-base shrink-0" />
+					{format}
+				</span>
+			)}
+			{format && size && <span class="text-gray-300">·</span>}
+			{size && (
+				<span class="inline-flex items-center gap-1">
+					<Icon name="mdi:weight" class="text-base shrink-0" />
+					{size}
+				</span>
+			)}
+		</div>
+	)}
+	<div class="px-5 pb-5 mt-auto">
+		<Button view="link" classes="w-full! m-0! btn justify-center!" url={url} target="_blank" title="Открыть PDF" />
+	</div>
+</div>

--- a/src/blocks/manuals/ManualMediaCard.astro
+++ b/src/blocks/manuals/ManualMediaCard.astro
@@ -1,0 +1,23 @@
+---
+// Плитка руководства с изображением модели (вариант бренда Toyota).
+import CardMedia from '@/ui/card-media/CardMedia.astro';
+import Button from '@/ui/button/Button.astro';
+
+interface Props {
+	image?: string;
+	name: string;
+	url: string;
+	imgPlacement?: 'left' | 'right';
+}
+const { image, name, url, imgPlacement = 'left' } = Astro.props;
+---
+<CardMedia imgPlacement={imgPlacement}>
+	<img slot="card-image" class="max-w-48 lg:p-10" src={image} alt={name} />
+	<Fragment slot="card-content">
+		<h2 class="!m-0 !p-0 before:hidden !text-xl lg:!text-3xl">Руководство по эксплуатации <span class="font-semibold">{name}</span></h2>
+		<div class="flex gap-3">
+			<Button view="link" classes="!m-0 btn" url={url} target="_blank" title="Посмотреть" />
+			<Button view="link" classes="!m-0 btn btn-o" url={url} download title="Скачать" />
+		</div>
+	</Fragment>
+</CardMedia>


### PR DESCRIPTION
Две переиспользуемые плитки страницы «Руководства по эксплуатации», вынесенные из инлайн-разметки toyota rukovodstvo. Аддитивно (новые компоненты, ничего не ломают). Используются страницами в astro-json (toyota.alexsab.ru + cars.toyota*.ru).

🤖 Generated with [Claude Code](https://claude.com/claude-code)