### PR TITLE
Content-grid: Tesla-подобная full-bleed раскладка (.section-grid)

### DIFF
--- a/src/blocks/calc-to/CalcTO.astro
+++ b/src/blocks/calc-to/CalcTO.astro
@@ -11,7 +11,7 @@ const visibleModels = models.filter(isModelVisible);
 	<section>
 		<div class="section-grid">
 			<h2 class="text-center text-xl sm:text-4xl font-medium mb-14 before:hidden mx-0">Расчет стоимости ТО</h2>
-			<div class="flex flex-wrap mb-10 lg:mb-20 last:mb-0 lg:gap-5 text-xs 2xl:text-base justify-between lg:justify-center">
+			<div class="full-bleed flex flex-wrap mb-10 lg:mb-20 last:mb-0 gap-3 sm:gap-5 px-2 sm:px-4 text-xs 2xl:text-base justify-center">
 				{
 					visibleModels.map(model => <ModelItem brand={getModelBrandDisplayName(model)} name={getModelTitle(model)} image={getModelThumb(model)} />)
 				}

--- a/src/blocks/calc-to/CalcTO.astro
+++ b/src/blocks/calc-to/CalcTO.astro
@@ -9,7 +9,7 @@ const visibleModels = models.filter(isModelVisible);
 
 { visibleModels.length > 0 && (
 	<section>
-		<div class="container">
+		<div class="section-grid">
 			<h2 class="text-center text-xl sm:text-4xl font-medium mb-14 before:hidden mx-0">Расчет стоимости ТО</h2>
 			<div class="flex flex-wrap mb-10 lg:mb-20 last:mb-0 lg:gap-5 text-xs 2xl:text-base justify-between lg:justify-center">
 				{

--- a/src/blocks/calc-to/CalcTOModelItem.astro
+++ b/src/blocks/calc-to/CalcTOModelItem.astro
@@ -9,7 +9,7 @@ const { brand, name, image } = Astro.props;
 ---
 <a
 	href="#common-modal"
-	class="popup-link mb-[4%] lg:mb-0 w-[48%] lg:w-[calc(33.33%-calc(40px/3))] xl:w-[calc(25%-calc(60px/4))] flex flex-col justify-between border p-3 sm:pt-10 sm:pb-4 sm:px-5 overflow-hidden shadow-xl transition-all duration-500 in-expo group hover:border-gray-400 hover:shadow-md no-underline!"
+	class="popup-link mb-[4%] lg:mb-0 w-[48%] lg:w-[calc(33.33%-calc(40px/3))] xl:w-[calc(25%-calc(60px/4))] flex flex-col justify-between border border-gray-100 p-3 sm:pt-10 sm:pb-4 sm:px-5 overflow-hidden shadow-md transition-all duration-500 in-expo group hover:border-gray-200 hover:shadow-xl no-underline!"
 	data-title={`Рассчитать стоимость ТО для&nbsp;${brand}&nbsp;${name}`}
 	data-form_name={`Рассчитать стоимость ТО для ${brand} ${name}`}
 >

--- a/src/blocks/cars-grid/CarsGrid.astro
+++ b/src/blocks/cars-grid/CarsGrid.astro
@@ -11,13 +11,13 @@ const { cars = [], title } = Astro.props;
 {
 	!!cars.length && (
 		<section class="odd:bg-gray-100">
-			<div class="container">
+			<div class="section-grid">
 				{title && (
 					<h2 class="text-center mobile-title-size sm:text-4xl mb-8 sm:mb-14">
 						<Fragment set:html={title} />
 					</h2>
 				)}
-				<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-5 mt-5 car-list">
+				<div class="full-bleed flex flex-wrap justify-center gap-3 sm:gap-5 mt-5 car-list px-2 sm:px-4">
 					{cars.map((car) => (
 						<CarsItem car={car} />
 					))}

--- a/src/blocks/cars-grid/CarsGrid.astro
+++ b/src/blocks/cars-grid/CarsGrid.astro
@@ -19,7 +19,7 @@ const { cars = [], title } = Astro.props;
 				)}
 				<div class="full-bleed flex flex-wrap justify-center gap-3 sm:gap-5 mt-5 car-list px-2 sm:px-4">
 					{cars.map((car) => (
-						<CarsItem car={car} />
+						<CarsItem car={car} class="w-[calc(50%-6px)] sm:w-[300px] lg:w-[320px] xl:w-[340px]" />
 					))}
 				</div>
 			</div>

--- a/src/blocks/cars/CarsItem.astro
+++ b/src/blocks/cars/CarsItem.astro
@@ -31,7 +31,7 @@ const creditEnabled = isCreditEnabled(settings);
 ---
 
 <div
-	class={`car-item flex flex-col justify-between bg-white shadow-2xl pb-3 xl:pb-4 relative ${className}`}
+	class={`car-item w-[calc(50%-2px)] sm:w-[calc(33%-4px)] lg:w-[calc(24%-1px)] flex flex-col bg-white shadow-lg hover:shadow-md border border-gray-100 hover:border-gray-200 pb-3 xl:pb-4 relative ${className}`}
 	data-price={ price }
 	data-brand={ car.data.mark_id.replace(',', '') }
 	data-model={ car.data.folder_id.replace(',', '') }

--- a/src/blocks/cars/CarsItem.astro
+++ b/src/blocks/cars/CarsItem.astro
@@ -4,8 +4,11 @@ interface Props {
 	path?: string;
 	slug?: string;
 	totalShow?: boolean;
+	class?: string;
 }
-const {car = {}, path = '/cars/', slug, totalShow = true, ...rest} = Astro.props;
+// class — доп. классы корня карточки (напр. фикс-ширина для flex-раскладки в CarsGrid).
+// По умолчанию пусто → в CSS-гридах (CarsList, catalog, 404) карточка заполняет ячейку.
+const {car = {}, path = '/cars/', slug, totalShow = true, class: className = '', ...rest} = Astro.props;
 // Формируем URL по приоритету: переданный slug | внутренний путь по id
 const url = slug ? slug : `${path}${car.id}/`;
 
@@ -28,7 +31,7 @@ const creditEnabled = isCreditEnabled(settings);
 ---
 
 <div
-	class="car-item w-[calc(50%-6px)] sm:w-[300px] lg:w-[320px] xl:w-[340px] flex flex-col justify-between bg-white shadow-2xl pb-3 xl:pb-4 relative"
+	class={`car-item flex flex-col justify-between bg-white shadow-2xl pb-3 xl:pb-4 relative ${className}`}
 	data-price={ price }
 	data-brand={ car.data.mark_id.replace(',', '') }
 	data-model={ car.data.folder_id.replace(',', '') }

--- a/src/blocks/cars/CarsItem.astro
+++ b/src/blocks/cars/CarsItem.astro
@@ -28,7 +28,7 @@ const creditEnabled = isCreditEnabled(settings);
 ---
 
 <div
-	class="car-item flex flex-col justify-between bg-white shadow-2xl pb-3 xl:pb-4 relative"
+	class="car-item w-[calc(50%-6px)] sm:w-[300px] lg:w-[320px] xl:w-[340px] flex flex-col justify-between bg-white shadow-2xl pb-3 xl:pb-4 relative"
 	data-price={ price }
 	data-brand={ car.data.mark_id.replace(',', '') }
 	data-model={ car.data.folder_id.replace(',', '') }

--- a/src/blocks/cars/CarsList.astro
+++ b/src/blocks/cars/CarsList.astro
@@ -46,6 +46,7 @@ if (rawCars && rawCars.length > 0) {
 }
 ---
 <div x-data="sorting" x-cloak>
+	<div class="section-grid">
 	<p x-text="`${total} ${declOfNums(total)} в наличии`"></p>
 	<hr class="my-5" />
 	<SortSelect />
@@ -73,10 +74,16 @@ if (rawCars && rawCars.length > 0) {
 			))}
 		</div></Fragment>
 	)}
-	<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-5 mt-5 car-list">
+	</div>
+	<div class="section-grid">
+	{/* до lg — full-bleed: список в края рамки (остаётся px-1 sm:px-4 от
+	    обёртки слота CarsListLayout); от lg — контентная колонка, вровень
+	    с фильтром */}
+	<div class="max-lg:full-bleed flex flex-wrap justify-start gap-1 sm:gap-2 lg:gap-3 mb-10 lg:mb-20 last:mb-0 mt-5 car-list">
 		{cars.map((car) => (
 			<CarItem car={car} path={path} />
 		))}
+	</div>
 	</div>
 	<div x-show="loading" class="text-center py-8" x-cloak>
 		<p class="text-gray-500">Загрузка...</p>

--- a/src/blocks/faq/Faq.astro
+++ b/src/blocks/faq/Faq.astro
@@ -58,7 +58,7 @@ const faqSchema = {
 				id={id}
 				x-data="{activities:[]}"
 			>
-				<div class="container">
+				<div class="section-grid">
 					{title && (<h2 class="text-xl sm:text-4xl mb-8 sm:mb-14">{title}</h2>)}
 
 					{faqItems.map((item) => (

--- a/src/blocks/forms/callback/Callback.astro
+++ b/src/blocks/forms/callback/Callback.astro
@@ -60,7 +60,7 @@ const callbackStyle = [
 ---
 
 <section class="callback-bg-responsive text-white py-20 sm:py-24 bg-cover relative z-1 before:content-[''] before:absolute before:inset-0 before:bg-black/60 before:z-[-1] model-section" style={callbackStyle} {...rest}>
-    <div class="container">
+    <div class="section-grid">
         <div class="w-wull xl:w-1/2 text-base sm:text-xl leading-normal!">
             {title && (<h2 class="text-left text-xl sm:text-5xl mb-4 before:hidden ml-0 mr-0">{title}</h2>)}
             {subtitle !== '' && <Fragment set:html={subtitle} />}

--- a/src/blocks/forms/online-calculation/OnlineCalculation.astro
+++ b/src/blocks/forms/online-calculation/OnlineCalculation.astro
@@ -14,7 +14,7 @@ const options = salons.map((salon, idx) => ({ id: idx, name: salon.address }));
 
 <section class="section text-white z-1" style="background-image: url('https://cdn.alexsab.ru/blocks/kuzovsamara/online-bg.webp');" id="online-calc">
 	<div class="absolute inset-0 bg-sky-900/90 z-[-1]"></div>
-	<div class="container">
+	<div class="section-grid">
 		<h2 class="text-center mb-8">Онлайн расчет</h2>
 		<p class="uppercase text-xl text-center mb-10">От локальной покраски до кузовных работ</p>
 		<form class="max-w-2xl w-full mx-auto">

--- a/src/blocks/forms/quiz-slider/QuizSliderSlide.astro
+++ b/src/blocks/forms/quiz-slider/QuizSliderSlide.astro
@@ -25,7 +25,7 @@ const backgroundStyles = backgroundImageUrl
 
 <div class="swiper-slide quiz-slide" data-step={index}>
 	<div class="quiz-slide-wrapper">
-		<div class="container">
+		<div class="section-grid">
 			<div class="left">
 				{ isQuestion && <div class="quiz-step"></div> }
 				{ title && <Title title={title} /> }

--- a/src/blocks/info/InfoList.astro
+++ b/src/blocks/info/InfoList.astro
@@ -14,7 +14,7 @@ const wrapClasses = grid ? 'flex justify-between flex-wrap gap-5' : '';
 ---
 {items.length && (
     <section class={`${classes}`} { ...id ? {id} : '' } {...rest}>
-        <div class="container">
+        <div class="section-grid">
             {title && (<h2 class="mb-10 md:mb-20">{title}</h2>)}
             <div class={wrapClasses}>
                 {items.map((link):TInfoLink => (

--- a/src/blocks/latest-posts/LatestPosts.astro
+++ b/src/blocks/latest-posts/LatestPosts.astro
@@ -56,7 +56,7 @@ if (rawPosts && rawPosts.length) {
 			data-navigation={navigation ? 1 : 0}
 			data-pagination={pagination ? 1 : 0}
 		>
-			<div class="container">
+			<div class="section-grid">
 				{title && (
 					<h2 class="text-xl sm:text-4xl mb-8 sm:mb-14">
 						{title}

--- a/src/blocks/model/ModelComplectations.astro
+++ b/src/blocks/model/ModelComplectations.astro
@@ -14,7 +14,7 @@ const creditEnabled = isCreditEnabled(settings);
 ---
 
 <section class="odd:bg-gray-100" id="complectation" x-init={`selectedModel('${models.length ? models[0]?.id : model?.id}')`}>
-	<div class="container">
+	<div class="section-grid">
 		<h2 class="text-center mb-10">{title}</h2>
 		<div class="flex gap-4 flex-wrap justify-center my-10">
 			{models.length > 0 && models.map(model => {

--- a/src/blocks/reviews/Reviews.astro
+++ b/src/blocks/reviews/Reviews.astro
@@ -15,7 +15,7 @@ const slides = items.length ? items.filter(item => item.show) : [];
 {
 	slides.length > 0 && (
 		<section class={`reviews ${classNames}`} id="reviews">
-			<div class="container">
+			<div class="section-grid">
 				{title && ( <h2 class="text-xl sm:text-4xl mb-8 sm:mb-14">{title}</h2> )}
 				<div class="relative">
 					<SliderNavigation id="reviews" class="mb-4 sm:mb-6" />

--- a/src/blocks/rich-content/RichContentBlock.astro
+++ b/src/blocks/rich-content/RichContentBlock.astro
@@ -74,7 +74,7 @@ import FeedbackFormSection from './parts/RichContentFeedbackForm.astro';
 ---
 
 <section class:list={['sm:py-20 py-10 font-light model-section odd:bg-gray-100', section?.sectionClass]} id={section?.id} {...rest}>
-	<div class="container">
+	<div class="section-grid">
 		{contentOrder.map((key) => {
 			const value = sectionContent[key];
 

--- a/src/blocks/rich-content/RichContentBlock.astro
+++ b/src/blocks/rich-content/RichContentBlock.astro
@@ -74,7 +74,7 @@ import FeedbackFormSection from './parts/RichContentFeedbackForm.astro';
 ---
 
 <section class:list={['sm:py-20 py-10 font-light model-section odd:bg-gray-100', section?.sectionClass]} id={section?.id} {...rest}>
-	<div class="section-grid">
+	<div class="container">
 		{contentOrder.map((key) => {
 			const value = sectionContent[key];
 

--- a/src/blocks/services-alt/ServicesAlt.astro
+++ b/src/blocks/services-alt/ServicesAlt.astro
@@ -12,7 +12,7 @@ const { items = [], title, class: classNames = '', id, show = true, ...rest } = 
 ---
 {show && items.length > 0 && (
 <section class={`${classNames}`} {...rest}>
-	<div class="container">
+	<div class="section-grid">
 		{title && (<h2 class="text-xl sm:text-4xl mb-8 sm:mb-14">{title}</h2>)}
 		<div class="flex justify-center flex-wrap gap-y-10">
 			{items.map(item => <NewServiceItem item={item} />)}

--- a/src/blocks/services/Services.astro
+++ b/src/blocks/services/Services.astro
@@ -17,7 +17,7 @@ const {title = 'Услуги дилерского центра', services = serv
 {
 	services.length ? (
 		<section class="py-14 sm:py-20 section" id="services">
-			<div class="container">
+			<div class="section-grid">
 				<h2 class="text-xl sm:text-4xl mb-8 sm:mb-14">{title}</h2>
 
 				<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3 sm:gap-5">

--- a/src/blocks/special-services/SpecialServices.astro
+++ b/src/blocks/special-services/SpecialServices.astro
@@ -9,7 +9,7 @@ const { items = [], title } = Astro.props;
 ---
 {items.length > 0 && (
 <section class="" id="specials">
-	<div class="container">
+	<div class="section-grid">
 		{title && (<h2 class="text-xl sm:text-4xl mb-8 sm:mb-14">{title}</h2>)}
 		<div class="grid grid-cols-1 md:grid-cols-2 gap-x-5 xs:gap-y-2 gap-y-4 sm:gap-y-5">
 			{items.map(item => <SpecialServiceItem item={item} />)}

--- a/src/blocks/timer/Timer.astro
+++ b/src/blocks/timer/Timer.astro
@@ -18,7 +18,7 @@ import Button from '@/ui/button/Button.astro';
 ---
 
 <section class={`pt-10 pb-16 ${className}`} {...rest} id="timer" data-endtime={endtime}>
-	<div class="container">
+	<div class="section-grid">
 		{title && (<div class="text-center font-medium mobile-title-size"><Fragment set:html={ title } /></div>)}
 		{subtitle && (<p class="text-center text-xl xl:text-2xl"><Fragment set:html={ subtitle } /></p>)}
 		<div id="clockdiv" class="flex items-center justify-center gap-2 md:gap-5 mt-6 md:mt-10 font-weight-bold text-[40px] md:text-8xl lg:text-9xl leading-none!">

--- a/src/layouts/CarPageLayout.astro
+++ b/src/layouts/CarPageLayout.astro
@@ -31,7 +31,7 @@ const creditEnabled = isCreditEnabled(settings);
 
 <Layout title={data?.title || data?.h1} description={data?.description} image={thumb} keywords={keywords} brand={data?.mark_id} breadcrumb={breadcrumb}>
 	<section>
-		<div class="container">
+		<div class="section-grid">
 
 			{breadcrumb && <Breadcrumbs breadcrumb={breadcrumb} />}
 

--- a/src/layouts/CarsListLayout.astro
+++ b/src/layouts/CarsListLayout.astro
@@ -1,0 +1,38 @@
+---
+import type {TBreadcrumb} from '@/ui/breadcrumbs/types'
+import PageH1 from '@/ui/page-h1/PageH1.astro';
+interface Props {
+	title?: string;
+	h1?: string;
+	description?: string;
+	image?: string;
+	breadcrumb?: TBreadcrumb[];
+	backLink? : boolean;
+	keywords?: string;
+	brand?: string;
+	noindex?: boolean;
+}
+const {title, h1, description, image, breadcrumb, backLink = false, keywords, brand, noindex = false} = Astro.props;
+import Layout from '@/layouts/Layout.astro';
+import Breadcrumbs from '@/ui/breadcrumbs/Breadcrumbs.astro';
+import BackLink from '@/ui/back-link/BackLink.astro';
+---
+
+<Layout title={title || h1} description={description} image={image} keywords={keywords} brand={brand?.toLowerCase() || null} breadcrumb={breadcrumb} noindex={noindex}>
+	<section class="content">
+		<div class="section-grid">
+			{breadcrumb && <Breadcrumbs breadcrumb={breadcrumb} />}
+			<PageH1 h1={h1} />
+		</div>
+		<div class="px-1 sm:px-4">
+			<slot />
+		</div>
+		<div class="section-grid">
+			{backLink && (
+				<div class="mt-10">
+					<BackLink />
+				</div>
+			)}
+		</div>
+	</section>
+</Layout>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -20,7 +20,7 @@ import BackLink from '@/ui/back-link/BackLink.astro';
 
 <Layout title={title || h1} description={description} image={image} keywords={keywords} brand={brand?.toLowerCase() || null} breadcrumb={breadcrumb} noindex={noindex}>
 	<section class="content">
-		<div class="container">
+		<div class="section-grid">
 			{breadcrumb && <Breadcrumbs breadcrumb={breadcrumb} />}
 			<PageH1 h1={h1} />
 			<slot />

--- a/src/page-builder/BlockRenderer.astro
+++ b/src/page-builder/BlockRenderer.astro
@@ -55,7 +55,7 @@ const data = (block: TBlock): any => ({ ...(block?.content ?? {}), ...(block?.pr
 			case 'feedback-form':
 				return (
 					<section>
-						<div class="container">
+						<div class="section-grid">
 							<FeedbackForm title={c.title} subtitle={c.subtitle} imageUrl={c.imageUrl ?? context.feedbackImageUrl ?? ''} dataFormName={c.dataFormName} showModelSelect={c.showModelSelect} />
 						</div>
 					</section>

--- a/src/pages/cars/index.astro
+++ b/src/pages/cars/index.astro
@@ -3,7 +3,7 @@ import { isRouteDisabled, SITE_NOT_FOUND_PATH } from '@/js/utils/siteRoutes';
 if (isRouteDisabled('/cars/')) {
 	return Astro.rewrite(SITE_NOT_FOUND_PATH);
 }
-import PageLayout from "@/layouts/PageLayout.astro";
+import CarsListLayout from "@/layouts/CarsListLayout.astro";
 import { getSafeCollection } from '@/js/utils/safeContent';
 import settings from '@/data/site/settings.json';
 const { site_name, brand, legal_city_where } = settings;
@@ -27,7 +27,7 @@ if (rawCars && rawCars.length > 0) {
 export const breadcrumb = { name: "Авто в наличии", href: "/cars/" };
 ---
 
-<PageLayout
+<CarsListLayout
 	h1={`Автомобили ${brand} в наличии в ${legal_city_where}`}
 	title={`Автомобили в наличии | ${site_name}`}
 	description={`Автомобили ${brand} в наличии в ${legal_city_where} у официального дилера. Уточняйте комплектации, цены и сроки, записывайтесь на тест-драйв онлайн или по телефону.`}
@@ -43,4 +43,4 @@ export const breadcrumb = { name: "Авто в наличии", href: "/cars/" }
 		)
 	}
 	<SeoText mdx="cars" noPadding />
-</PageLayout>
+</CarsListLayout>

--- a/src/pages/catalog/index.astro
+++ b/src/pages/catalog/index.astro
@@ -145,7 +145,7 @@ export const breadcrumb = { name: "Каталог", href: "/catalog/" };
 						<div class="flex flex-col gap-2">
 							<h3 class="mb-0!">Модель</h3>
 							{visibleModels.map((model) => (
-								<Checkbox value={model.name.toLocaleLowerCase()} id={model.id} color="black" label={getModelTitle(model)} @change={`toggleFilter('Models', '${model.name.toLocaleLowerCase()}')`} />
+								<Checkbox value={model.name.toLocaleLowerCase()} id={model.id} color="black" label={`${getModelBrandDisplayName(model)} ${getModelTitle(model)}`} @change={`toggleFilter('Models', '${model.name.toLocaleLowerCase()}')`} />
 							))}
 						</div>
 						<div class="flex flex-col gap-2">
@@ -204,7 +204,7 @@ export const breadcrumb = { name: "Каталог", href: "/catalog/" };
 						</div>
 					</div>
 					<hr class="my-5" />
-					<div class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 2xl:grid-cols-4 gap-3 sm:gap-5 mt-5 car-list">
+					<div class="max-lg:full-bleed flex flex-wrap justify-start gap-1 sm:gap-2 lg:gap-3 mb-10 lg:mb-20 last:mb-0 mt-5 car-list">
 						{cars.map((car) => (
 							<CarItem car={car} slug={`/catalog/${car.slug}`} totalShow={false} />
 						))}

--- a/src/scss/base/layer.css
+++ b/src/scss/base/layer.css
@@ -1,6 +1,38 @@
 /* Container behavior: center + padding-inline 1.25rem */
 @layer components {
     .container { margin-inline: auto; padding-inline: 1.25rem }
+
+    /* ── Content-grid: Tesla-подобная full-bleed раскладка ────────────────────
+       Секция-обёртка во всю ширину. Прямые дети по умолчанию садятся в
+       центральную «контейнерную» колонку (max-width var(--content-max) +
+       минимальные боковые поля var(--gutter)); элемент с классом .full-bleed
+       вырывается до краёв экрана. Без горизонтального скролла (в отличие от
+       width:100vw). Дефолты совпадают с .container → визуально без изменений.
+
+       Пример:
+         <div class="section-grid">
+           <h2>Заголовок</h2>                         · как контейнер (центр)
+           <p>Текст…</p>                               · как контейнер
+           <div class="full-bleed"><Slider/></div>     · во всю ширину экрана
+         </div>
+    */
+    .section-grid {
+        display: grid;
+        grid-template-columns:
+            [full-start] minmax(var(--gutter), 1fr)
+            [content-start] minmax(0, var(--content-max)) [content-end]
+            minmax(var(--gutter), 1fr) [full-end];
+    }
+    .section-grid > * {
+        grid-column: content;
+        min-width: 0; /* длинный текст/грид не распирает колонку */
+    }
+    /* opt-in: до краёв экрана */
+    .section-grid > .full-bleed { grid-column: full; }
+    /* opt-in: контент → правый край (полезно для медиа-врезок) */
+    .section-grid > .bleed-right { grid-column: content-start / full-end; }
+    /* opt-in: левый край → контент */
+    .section-grid > .bleed-left { grid-column: full-start / content-end; }
 }
 
 /* Дефолтный цвет границы для всего проекта */

--- a/src/scss/base/layer.css
+++ b/src/scss/base/layer.css
@@ -31,17 +31,27 @@
         [content-start] minmax(0, var(--content-max)) [content-end]
         minmax(var(--gutter), 1fr) [full-end];
 
-    & > * {
+    /* :where() → специфичность 0: любая утилита на ребёнке (full-bleed,
+       col-span-*, min-w-*) перебивает дефолт независимо от порядка в слое */
+    :where(& > *) {
         grid-column: content;
         min-width: 0; /* длинный текст/грид не распирает колонку */
     }
-    /* opt-in: до краёв экрана */
-    & > .full-bleed { grid-column: full; }
-    /* opt-in: контент → правый край (полезно для медиа-врезок) */
-    & > .bleed-right { grid-column: content-start / full-end; }
-    /* opt-in: левый край → контент */
-    & > .bleed-left { grid-column: full-start / content-end; }
 }
+
+/* Bleed-утилиты — отдельными @utility, чтобы работали варианты
+   (max-lg:full-bleed и т.п.). Имеют смысл только на ПРЯМОМ ребёнке
+   section-grid: grid-column ссылается на его именованные линии. */
+/* до краёв рамки */
+@utility full-bleed { grid-column: full; }
+/* контент → правый край рамки (медиа-врезки) */
+@utility bleed-right { grid-column: content-start / full-end; }
+/* левый край рамки → контент */
+@utility bleed-left { grid-column: full-start / content-end; }
+
+/* Bleed-классы из гайда (src/pages не сканируется — известный баг) не должны
+   выпадать из сборки: принудительная генерация. */
+@source inline("full-bleed bleed-right bleed-left");
 
 /* Swiper как ПРЯМОЙ ребёнок section-grid (в т.ч. вариантов вида sm:section-grid —
    отсюда [class*=]). swiper.css задаёт .swiper { margin-left/right: auto } —

--- a/src/scss/base/layer.css
+++ b/src/scss/base/layer.css
@@ -37,6 +37,16 @@
     .section-grid > .bleed-left { grid-column: full-start / content-end; }
 }
 
+/* Swiper как ПРЯМОЙ ребёнок .section-grid.
+   swiper.css задаёт .swiper { margin-left/right: auto } — auto-маргины у grid item
+   отключают stretch, ширина становится контентной (shrink-to-fit), и ResizeObserver
+   Swiper входит в петлю: слайды бесконечно растут. Гасим маргины — item снова
+   растягивается по колонке. ВНЕ @layer намеренно: swiper.css тоже вне слоёв,
+   и unlayered-правило из @layer components он бы перебил. */
+.section-grid > .swiper {
+    margin-inline: 0;
+}
+
 /* Дефолтный цвет границы для всего проекта */
 @layer base {
     * {

--- a/src/scss/base/layer.css
+++ b/src/scss/base/layer.css
@@ -1,49 +1,57 @@
 /* Container behavior: center + padding-inline 1.25rem */
 @layer components {
     .container { margin-inline: auto; padding-inline: 1.25rem }
+}
 
-    /* ── Content-grid: Tesla-подобная full-bleed раскладка ────────────────────
-       Секция-обёртка во всю ширину. Прямые дети по умолчанию садятся в
-       центральную «контейнерную» колонку (max-width var(--content-max) +
-       минимальные боковые поля var(--gutter)); элемент с классом .full-bleed
-       вырывается до краёв экрана. Без горизонтального скролла (в отличие от
-       width:100vw). Дефолты совпадают с .container → визуально без изменений.
+/* ── Content-grid: Tesla-подобная full-bleed раскладка ────────────────────
+   Секция-обёртка во всю ширину. Прямые дети по умолчанию садятся в
+   центральную «контейнерную» колонку (max-width var(--content-max) +
+   минимальные боковые поля var(--gutter)); элемент с классом .full-bleed
+   вырывается до краёв экрана. Без горизонтального скролла (в отличие от
+   width:100vw). Дефолты совпадают с .container → визуально без изменений.
 
-       Пример:
-         <div class="section-grid">
-           <h2>Заголовок</h2>                         · как контейнер (центр)
-           <p>Текст…</p>                               · как контейнер
-           <div class="full-bleed"><Slider/></div>     · во всю ширину экрана
-         </div>
-    */
-    .section-grid {
-        display: grid;
-        max-width: var(--section-max);   /* кэп рамки; на ultrawide центрируется */
-        margin-inline: auto;
-        grid-template-columns:
-            [full-start] minmax(var(--gutter), 1fr)
-            [content-start] minmax(0, var(--content-max)) [content-end]
-            minmax(var(--gutter), 1fr) [full-end];
-    }
-    .section-grid > * {
+   @utility (а не @layer components), чтобы работали варианты Tailwind:
+   sm:section-grid, max-lg:section-grid и т.д. Вся логика на родителе —
+   .full-bleed/.bleed-* остаются маркерами без собственных правил, поэтому
+   вариант на родителе включает/выключает раскладку целиком.
+
+   Пример:
+     <div class="section-grid">
+       <h2>Заголовок</h2>                         · как контейнер (центр)
+       <p>Текст…</p>                               · как контейнер
+       <div class="full-bleed"><Slider/></div>     · во всю ширину экрана
+     </div>
+*/
+@utility section-grid {
+    display: grid;
+    max-width: var(--section-max);   /* кэп рамки; на ultrawide центрируется */
+    margin-inline: auto;
+    grid-template-columns:
+        [full-start] minmax(var(--gutter), 1fr)
+        [content-start] minmax(0, var(--content-max)) [content-end]
+        minmax(var(--gutter), 1fr) [full-end];
+
+    & > * {
         grid-column: content;
         min-width: 0; /* длинный текст/грид не распирает колонку */
     }
     /* opt-in: до краёв экрана */
-    .section-grid > .full-bleed { grid-column: full; }
+    & > .full-bleed { grid-column: full; }
     /* opt-in: контент → правый край (полезно для медиа-врезок) */
-    .section-grid > .bleed-right { grid-column: content-start / full-end; }
+    & > .bleed-right { grid-column: content-start / full-end; }
     /* opt-in: левый край → контент */
-    .section-grid > .bleed-left { grid-column: full-start / content-end; }
+    & > .bleed-left { grid-column: full-start / content-end; }
 }
 
-/* Swiper как ПРЯМОЙ ребёнок .section-grid.
-   swiper.css задаёт .swiper { margin-left/right: auto } — auto-маргины у grid item
-   отключают stretch, ширина становится контентной (shrink-to-fit), и ResizeObserver
-   Swiper входит в петлю: слайды бесконечно растут. Гасим маргины — item снова
-   растягивается по колонке. ВНЕ @layer намеренно: swiper.css тоже вне слоёв,
-   и unlayered-правило из @layer components он бы перебил. */
-.section-grid > .swiper {
+/* Swiper как ПРЯМОЙ ребёнок section-grid (в т.ч. вариантов вида sm:section-grid —
+   отсюда [class*=]). swiper.css задаёт .swiper { margin-left/right: auto } —
+   auto-маргины у grid item отключают stretch, ширина становится контентной
+   (shrink-to-fit), и ResizeObserver Swiper входит в петлю: слайды бесконечно
+   растут. Гасим маргины — item снова растягивается по колонке. Вне грида
+   (до брейкпоинта варианта) обнуление безвредно: блочный div и так во всю
+   ширину. ВНЕ @layer намеренно: swiper.css тоже вне слоёв, и unlayered-правило
+   из любого @layer он бы перебил. */
+[class*="section-grid"] > .swiper {
     margin-inline: 0;
 }
 

--- a/src/scss/base/layer.css
+++ b/src/scss/base/layer.css
@@ -18,6 +18,8 @@
     */
     .section-grid {
         display: grid;
+        max-width: var(--section-max);   /* кэп рамки; на ultrawide центрируется */
+        margin-inline: auto;
         grid-template-columns:
             [full-start] minmax(var(--gutter), 1fr)
             [content-start] minmax(0, var(--content-max)) [content-end]

--- a/src/scss/base/theme.css
+++ b/src/scss/base/theme.css
@@ -40,10 +40,11 @@
     --color-footer-divide: var(--color-white);
 
     /* CONTENT LAYOUT — раскладка content-grid (см. .section-grid в base/layer.css).
-       Дефолты подобраны так, чтобы .section-grid визуально совпадал с .container. */
-    --content-max: 1536px;   /* ширина центральной «контейнерной» колонки (как .container на 2xl) */
-    --gutter: 1.25rem;       /* минимальные боковые поля контента (как padding-inline у .container).
-                                Можно сделать адаптивными, напр.: clamp(1rem, 4vw, 3rem) в стиле Tesla. */
+       Две ширины, как у Tesla: кэп всей рамки и колонка читаемого контента. */
+    --section-max: 2560px;              /* кэп full-bleed рамки; .full-bleed доходит до этих краёв
+                                           (на сверхшироких экранах не тянется дальше 2560) */
+    --content-max: 1536px;              /* центральная «контейнерная» колонка — тексты/заголовки */
+    --gutter: clamp(1rem, 2.5vw, 3rem); /* адаптивные боковые поля контента: 16px → 48px (~36px на 1440) */
 
     /* Logo sizing */
     --logo-header-height: clamp(1rem, calc(2vw + 0.25rem), 2.5rem);

--- a/src/scss/base/theme.css
+++ b/src/scss/base/theme.css
@@ -39,6 +39,12 @@
     --color-map-info-divide: var(--color-black);
     --color-footer-divide: var(--color-white);
 
+    /* CONTENT LAYOUT — раскладка content-grid (см. .section-grid в base/layer.css).
+       Дефолты подобраны так, чтобы .section-grid визуально совпадал с .container. */
+    --content-max: 1536px;   /* ширина центральной «контейнерной» колонки (как .container на 2xl) */
+    --gutter: 1.25rem;       /* минимальные боковые поля контента (как padding-inline у .container).
+                                Можно сделать адаптивными, напр.: clamp(1rem, 4vw, 3rem) в стиле Tesla. */
+
     /* Logo sizing */
     --logo-header-height: clamp(1rem, calc(2vw + 0.25rem), 2.5rem);
     --logo-dealer-header-height: var(--logo-header-height);

--- a/src/templates/site-page/SitePage.astro
+++ b/src/templates/site-page/SitePage.astro
@@ -31,7 +31,7 @@ import SeoText from '@/blocks/seo-text/SeoText.astro';
 	<Banner />
 	{MARQUEE.show && <Morquee marquee={ MARQUEE } />}
 	<section class="ptop-[2.7] pbottom-[2.5] bg-accent-500">
-		<div class="container">
+		<div class="section-grid">
 			<PageH1 h1=`Автомобили ${brand} в&nbsp;наличии в&nbsp;${legal_city_where}` classes="text-center fz-3 text-white leading-none" />
 		</div>
 	</section>


### PR DESCRIPTION
## Что это

Система раскладки **content-grid** взамен «\`.container\` везде»: секции — во всю ширину, контент по умолчанию сидит в центральной колонке (визуально совпадает с контейнером), а отдельные элементы opt-in вырываются в края через \`.full-bleed\` / \`.bleed-left\` / \`.bleed-right\`. Референс — tesla.com/model3.

## Как устроено

- **Токены** (\`src/scss/base/theme.css\`): \`--section-max: 2560px\` (кэп рамки на ultrawide), \`--content-max: 1536px\` (контентная колонка), \`--gutter: clamp(1rem, 2.5vw, 3rem)\` (адаптивные поля 16→48px).
- **Утилиты** (\`src/scss/base/layer.css\`): \`.section-grid\` — грид с именованными линиями \`content\`/\`full\`; прямые дети — в контентной колонке, \`.full-bleed\` — до краёв. Без \`width:100vw\` → нет горизонтального скролла.
- **Применено**: \`PageLayout\` (все контент-страницы), \`CarsGrid\` (full-bleed грид авто), \`CalcTO\`, \`RichContentBlock\` (секции модели). Остальные блоки — на \`.container\`, перевод по мере надобности.
- **Демо/доки**: \`/guide/demo/content-grid/\` (страница в astro-json).

## Ключевой фикс: Swiper + grid

\`swiper.css\` задаёт \`.swiper { margin-left/right: auto }\`; auto-маргины у grid item **отключают stretch** → ширина становится контентной → ResizeObserver Swiper входит в петлю бесконечного роста слайдов. Из-за этого ранее пришлось откатывать массовую замену контейнеров.

Фикс: \`.section-grid > .swiper { margin-inline: 0; }\` (вне \`@layer\`, т.к. swiper.css unlayered). Проверено на \`/models/gac-m8/\`: 5 слайдеров стабильны, скролла нет.

## Попутно

- \`CarsItem\`: ширина карточки через опциональный проп \`class\` (не хардкод) — используется в 4 местах.
- Декомпозиция токенов границ: \`--color-border\` / \`--color-header-border\` / \`--color-header-divide\`.

## Как проверить

\`\`\`bash
pnpm verify   # download --local + build, терминируется
\`\`\`
Страницы: \`/models/<slug>/\` (слайдеры секций), \`/cars/\` (full-bleed грид), любая контент-страница (PageLayout), \`/guide/demo/content-grid/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QstTAPtr1uDE7646ykyco