### PR TITLE
feat(schema-org): render strict v2 structured data

### DIFF
--- a/.github/scripts/validateSchemaOrgDist.mjs
+++ b/.github/scripts/validateSchemaOrgDist.mjs
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+function listHtmlFiles(directory) {
+	const files = [];
+
+	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+		const entryPath = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...listHtmlFiles(entryPath));
+		} else if (entry.isFile() && entry.name.endsWith('.html')) {
+			files.push(entryPath);
+		}
+	}
+
+	return files;
+}
+
+export function validateJsonLdHtml(html, location = 'HTML') {
+	const errors = [];
+	const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+	let jsonLdCount = 0;
+
+	for (const match of html.matchAll(scriptPattern)) {
+		if (
+			!/\btype\s*=\s*["']application\/ld\+json["']/i.test(match[1])
+		) {
+			continue;
+		}
+
+		jsonLdCount += 1;
+		try {
+			JSON.parse(match[2]);
+		} catch (error) {
+			errors.push(
+				`${location}: JSON-LD script ${jsonLdCount} is invalid: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+
+	return { errors, jsonLdCount };
+}
+
+export function validateJsonLdDist(directory) {
+	if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+		return {
+			errors: [`Build directory not found: ${directory}`],
+			htmlCount: 0,
+			jsonLdCount: 0,
+		};
+	}
+
+	const htmlFiles = listHtmlFiles(directory);
+	const errors = [];
+	let jsonLdCount = 0;
+
+	for (const filePath of htmlFiles) {
+		const result = validateJsonLdHtml(
+			fs.readFileSync(filePath, 'utf8'),
+			filePath,
+		);
+		errors.push(...result.errors);
+		jsonLdCount += result.jsonLdCount;
+	}
+
+	return { errors, htmlCount: htmlFiles.length, jsonLdCount };
+}
+
+function main() {
+	const directory = path.resolve(process.argv[2] ?? 'dist');
+	const result = validateJsonLdDist(directory);
+
+	if (result.errors.length > 0) {
+		console.error(
+			`JSON-LD validation failed with ${result.errors.length} error(s):`,
+		);
+		for (const error of result.errors) {
+			console.error(`- ${error}`);
+		}
+		process.exitCode = 1;
+		return;
+	}
+
+	console.log(
+		`OK: parsed ${result.jsonLdCount} JSON-LD script(s) in ${result.htmlCount} HTML file(s).`,
+	);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	main();
+}

--- a/.github/scripts/validateSchemaOrgDist.mjs
+++ b/.github/scripts/validateSchemaOrgDist.mjs
@@ -3,6 +3,8 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+const SCHEMA_ORG_MODES = new Set(['optional', 'required', 'absent']);
+
 function listHtmlFiles(directory) {
 	const files = [];
 
@@ -18,15 +20,43 @@ function listHtmlFiles(directory) {
 	return files;
 }
 
-export function validateJsonLdHtml(html, location = 'HTML') {
+function isSchemaOrgScript(attributes) {
+	return /\bid\s*=\s*["']schema-org["']/i.test(attributes);
+}
+
+function isJsonLdScript(attributes) {
+	return /\btype\s*=\s*["']application\/ld\+json["']/i.test(attributes);
+}
+
+export function validateJsonLdHtml(
+	html,
+	location = 'HTML',
+	{ schemaOrg = 'optional' } = {},
+) {
+	if (!SCHEMA_ORG_MODES.has(schemaOrg)) {
+		throw new TypeError(`Unknown SchemaOrg presence mode: ${schemaOrg}`);
+	}
+
 	const errors = [];
 	const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
 	let jsonLdCount = 0;
+	let schemaOrgCount = 0;
 
 	for (const match of html.matchAll(scriptPattern)) {
-		if (
-			!/\btype\s*=\s*["']application\/ld\+json["']/i.test(match[1])
-		) {
+		const attributes = match[1];
+		const isSchemaOrg = isSchemaOrgScript(attributes);
+		const isJsonLd = isJsonLdScript(attributes);
+
+		if (isSchemaOrg) {
+			schemaOrgCount += 1;
+			if (!isJsonLd) {
+				errors.push(
+					`${location}: script#schema-org must use type="application/ld+json"`,
+				);
+			}
+		}
+
+		if (!isJsonLd) {
 			continue;
 		}
 
@@ -42,37 +72,127 @@ export function validateJsonLdHtml(html, location = 'HTML') {
 		}
 	}
 
-	return { errors, jsonLdCount };
+	if (schemaOrgCount > 1) {
+		errors.push(
+			`${location}: expected at most one script#schema-org, found ${schemaOrgCount}`,
+		);
+	}
+
+	if (schemaOrg === 'required' && schemaOrgCount === 0) {
+		errors.push(`${location}: expected script#schema-org, found none`);
+	}
+
+	if (schemaOrg === 'absent' && schemaOrgCount > 0) {
+		errors.push(
+			`${location}: expected no script#schema-org, found ${schemaOrgCount}`,
+		);
+	}
+
+	return { errors, jsonLdCount, schemaOrgCount };
 }
 
-export function validateJsonLdDist(directory) {
+export function validateJsonLdDist(
+	directory,
+	{ schemaOrg = 'optional' } = {},
+) {
+	if (!SCHEMA_ORG_MODES.has(schemaOrg)) {
+		throw new TypeError(`Unknown SchemaOrg presence mode: ${schemaOrg}`);
+	}
+
 	if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
 		return {
 			errors: [`Build directory not found: ${directory}`],
 			htmlCount: 0,
 			jsonLdCount: 0,
+			schemaOrgCount: 0,
+			htmlWithSchemaOrgCount: 0,
 		};
 	}
 
 	const htmlFiles = listHtmlFiles(directory);
 	const errors = [];
 	let jsonLdCount = 0;
+	let schemaOrgCount = 0;
+	let htmlWithSchemaOrgCount = 0;
 
 	for (const filePath of htmlFiles) {
 		const result = validateJsonLdHtml(
 			fs.readFileSync(filePath, 'utf8'),
 			filePath,
+			{ schemaOrg: schemaOrg === 'absent' ? 'absent' : 'optional' },
 		);
 		errors.push(...result.errors);
 		jsonLdCount += result.jsonLdCount;
+		schemaOrgCount += result.schemaOrgCount;
+		if (result.schemaOrgCount > 0) {
+			htmlWithSchemaOrgCount += 1;
+		}
 	}
 
-	return { errors, htmlCount: htmlFiles.length, jsonLdCount };
+	if (schemaOrg === 'required' && schemaOrgCount === 0) {
+		errors.push(
+			`${directory}: expected at least one script#schema-org, found none`,
+		);
+	}
+
+	return {
+		errors,
+		htmlCount: htmlFiles.length,
+		jsonLdCount,
+		schemaOrgCount,
+		htmlWithSchemaOrgCount,
+	};
+}
+
+export function parseArguments(args) {
+	let directory;
+	let schemaOrg = 'optional';
+
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+
+		if (argument === '--schema-org') {
+			schemaOrg = args[index + 1];
+			index += 1;
+		} else if (argument.startsWith('--schema-org=')) {
+			schemaOrg = argument.slice('--schema-org='.length);
+		} else if (argument.startsWith('-')) {
+			throw new TypeError(`Unknown argument: ${argument}`);
+		} else if (directory === undefined) {
+			directory = argument;
+		} else {
+			throw new TypeError(`Unexpected argument: ${argument}`);
+		}
+	}
+
+	if (!SCHEMA_ORG_MODES.has(schemaOrg)) {
+		throw new TypeError(
+			'--schema-org must be one of: optional, required, absent',
+		);
+	}
+
+	return {
+		directory: path.resolve(directory ?? 'dist'),
+		schemaOrg,
+	};
 }
 
 function main() {
-	const directory = path.resolve(process.argv[2] ?? 'dist');
-	const result = validateJsonLdDist(directory);
+	let options;
+	try {
+		options = parseArguments(process.argv.slice(2));
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		console.error(
+			'Usage: validateSchemaOrgDist.mjs [directory] [--schema-org=optional|required|absent]',
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	const result = validateJsonLdDist(options.directory, {
+		schemaOrg: options.schemaOrg,
+	});
 
 	if (result.errors.length > 0) {
 		console.error(
@@ -86,7 +206,7 @@ function main() {
 	}
 
 	console.log(
-		`OK: parsed ${result.jsonLdCount} JSON-LD script(s) in ${result.htmlCount} HTML file(s).`,
+		`OK: parsed ${result.jsonLdCount} JSON-LD script(s) in ${result.htmlCount} HTML file(s); found ${result.schemaOrgCount} script#schema-org in ${result.htmlWithSchemaOrgCount} file(s) (${options.schemaOrg}).`,
 	);
 }
 

--- a/.github/scripts/validateSchemaOrgDist.test.mjs
+++ b/.github/scripts/validateSchemaOrgDist.test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
-import { validateJsonLdHtml } from './validateSchemaOrgDist.mjs';
+import {
+	parseArguments,
+	validateJsonLdDist,
+	validateJsonLdHtml,
+} from './validateSchemaOrgDist.mjs';
 
 test('parses every JSON-LD script regardless of attribute order', () => {
 	const result = validateJsonLdHtml(`
@@ -9,7 +16,11 @@ test('parses every JSON-LD script regardless of attribute order', () => {
 		<script type="module">{"ignored":true}</script>
 	`);
 
-	assert.deepEqual(result, { errors: [], jsonLdCount: 2 });
+	assert.deepEqual(result, {
+		errors: [],
+		jsonLdCount: 2,
+		schemaOrgCount: 0,
+	});
 });
 
 test('reports malformed JSON-LD with its script position', () => {
@@ -21,4 +32,76 @@ test('reports malformed JSON-LD with its script position', () => {
 	assert.equal(result.jsonLdCount, 1);
 	assert.equal(result.errors.length, 1);
 	assert.match(result.errors[0], /page\.html: JSON-LD script 1 is invalid/);
+});
+
+test('required mode fails when a built site has no script#schema-org', (t) => {
+	const directory = fs.mkdtempSync(
+		path.join(os.tmpdir(), 'schema-org-required-'),
+	);
+	t.after(() => fs.rmSync(directory, { recursive: true }));
+	fs.writeFileSync(
+		path.join(directory, 'index.html'),
+		'<script type="application/ld+json">{"@type":"Thing"}</script>',
+	);
+
+	const result = validateJsonLdDist(directory, {
+		schemaOrg: 'required',
+	});
+
+	assert.equal(result.jsonLdCount, 1);
+	assert.equal(result.schemaOrgCount, 0);
+	assert.equal(result.errors.length, 1);
+	assert.match(result.errors[0], /expected at least one script#schema-org/);
+});
+
+test('absent mode fails when a control build contains script#schema-org', (t) => {
+	const directory = fs.mkdtempSync(
+		path.join(os.tmpdir(), 'schema-org-absent-'),
+	);
+	t.after(() => fs.rmSync(directory, { recursive: true }));
+	fs.writeFileSync(
+		path.join(directory, 'index.html'),
+		'<script id="schema-org" type="application/ld+json">[]</script>',
+	);
+
+	const result = validateJsonLdDist(directory, {
+		schemaOrg: 'absent',
+	});
+
+	assert.equal(result.schemaOrgCount, 1);
+	assert.equal(result.errors.length, 1);
+	assert.match(result.errors[0], /expected no script#schema-org/);
+});
+
+test('rejects duplicate script#schema-org ids in one HTML page', () => {
+	const result = validateJsonLdHtml(
+		[
+			'<script id="schema-org" type="application/ld+json">[]</script>',
+			'<script type="application/ld+json" id="schema-org">[]</script>',
+		].join(''),
+		'duplicate.html',
+	);
+
+	assert.equal(result.jsonLdCount, 2);
+	assert.equal(result.schemaOrgCount, 2);
+	assert.equal(result.errors.length, 1);
+	assert.match(
+		result.errors[0],
+		/duplicate\.html: expected at most one script#schema-org, found 2/,
+	);
+});
+
+test('parses explicit CLI presence modes and rejects unknown values', () => {
+	assert.deepEqual(parseArguments(['build', '--schema-org=required']), {
+		directory: path.resolve('build'),
+		schemaOrg: 'required',
+	});
+	assert.deepEqual(parseArguments(['--schema-org', 'absent']), {
+		directory: path.resolve('dist'),
+		schemaOrg: 'absent',
+	});
+	assert.throws(
+		() => parseArguments(['--schema-org=unexpected']),
+		/optional, required, absent/,
+	);
 });

--- a/.github/scripts/validateSchemaOrgDist.test.mjs
+++ b/.github/scripts/validateSchemaOrgDist.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateJsonLdHtml } from './validateSchemaOrgDist.mjs';
+
+test('parses every JSON-LD script regardless of attribute order', () => {
+	const result = validateJsonLdHtml(`
+		<script id="first" type="application/ld+json">{"@type":"Thing"}</script>
+		<script type='application/ld+json' id='second'>[{"@type":"ItemList"}]</script>
+		<script type="module">{"ignored":true}</script>
+	`);
+
+	assert.deepEqual(result, { errors: [], jsonLdCount: 2 });
+});
+
+test('reports malformed JSON-LD with its script position', () => {
+	const result = validateJsonLdHtml(
+		'<script type="application/ld+json">{"broken":}</script>',
+		'page.html',
+	);
+
+	assert.equal(result.jsonLdCount, 1);
+	assert.equal(result.errors.length, 1);
+	assert.match(result.errors[0], /page\.html: JSON-LD script 1 is invalid/);
+});

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "interlink_map_dist": "node .github/scripts/interlinkMap/interlinkMap.js -- --from-dist",
     "interlink_lookup": "node .github/scripts/interlinkMap/lookupPath.js",
     "test_local": "node .github/scripts/checkLinks/test_local_check_links.js",
+    "test:schema-org": "node --test src/integrations/schema-org/schemaOrg.test.js .github/scripts/validateSchemaOrgDist.test.mjs",
+    "test:schema-org-dist": "node .github/scripts/validateSchemaOrgDist.mjs",
     "lighthouse": "astro build && astro preview --port 4343 & sleep 5 && npx lighthouse http://localhost:4343 --output=json --output-path=./lighthouse-report-$(date +%Y-%m-%d-%H-%M-%S).json",
     "prebuild": "node .github/scripts/setBrand.mjs",
     "build_local": "astro build --config astro.local.config.mjs",

--- a/src/integrations/schema-org/SchemaOrg.astro
+++ b/src/integrations/schema-org/SchemaOrg.astro
@@ -1,97 +1,47 @@
 ---
 import type { TBreadcrumb } from '@/ui/breadcrumbs/types';
 import { LINKS_MENU } from '@/const.js';
+import settings from '@/data/site/settings.json';
+import {
+	composeSchemaOrg,
+	serializeJsonLd,
+} from './schemaOrg.js';
 
 interface Props {
-  breadcrumbs?: TBreadcrumb[];
+	breadcrumbs?: TBreadcrumb[];
 }
 
-const { breadcrumbs } = Astro.props;
+const { breadcrumbs = [] } = Astro.props;
+const schemaModules = import.meta.glob('/src/data/site/schema.json', {
+	eager: true,
+});
+const schemaModule = Object.values(schemaModules)[0] as
+	| { default?: unknown }
+	| undefined;
+const features = (
+	settings as { features?: Record<string, unknown> }
+).features;
 
-let schema: Record<string, unknown | unknown[]> = {};
-
-try {
-  const mod = import.meta.glob('/src/data/site/schema.json', { eager: true });
-  schema = (Object.values(mod)[0] as any)?.default || [];
-} catch {
-  // schema.json не существует — просто не рендерим разметку
-}
-
-const currentPath = Astro.url.pathname;
-const raw = schema[currentPath];
-const schemas = raw ? (Array.isArray(raw) ? raw : [raw]) : [];
-
-const siteUrl = Astro.site?.href.replace(/\/$/, '') ?? '';
-
-const breadcrumbListSchema = breadcrumbs && breadcrumbs.length > 0 && schemas.length > 0
-  ? {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Главная", "item": siteUrl + "/" },
-        ...breadcrumbs.map((crumb, i) => ({
-          "@type": "ListItem",
-          "position": i + 2,
-          "name": crumb.name,
-          "item": siteUrl + crumb.href,
-        }))
-      ]
-    }
-  : null;
-
-const isValidUrl = (url: unknown): url is string =>
-  typeof url === 'string' &&
-  !url.startsWith('/#') &&
-  !url.startsWith('javascript:');
-
-const flatNavLinks: { name: string; url: string }[] = [];
-const pushNavLink = (name: unknown, url: unknown) => {
-  if (typeof name === 'string' && isValidUrl(url)) {
-    flatNavLinks.push({ name, url: siteUrl + url });
-  }
-};
-
-for (const link of LINKS_MENU as any[]) {
-  pushNavLink(link?.name, link?.url);
-
-  if (Array.isArray(link.children)) {
-    for (const child of link.children) {
-      pushNavLink(child?.name, child?.url);
-    }
-  } else if (link.children && typeof link.children === 'object') {
-    for (const brandItems of Object.values(link.children as Record<string, unknown>)) {
-      if (!Array.isArray(brandItems)) continue;
-
-      for (const child of brandItems) {
-        pushNavLink((child as { name?: unknown })?.name, (child as { url?: unknown })?.url);
-      }
-    }
-  }
-}
-
-const navItems = flatNavLinks.map((link, i) => ({
-  "@type": "SiteNavigationElement",
-  "position": i + 1,
-  "name": link.name,
-  "url": link.url,
-}));
-
-const navSchema = navItems.length > 0 && schemas.length > 0
-  ? {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      "name": "Главное меню",
-      "itemListElement": navItems,
-    }
-  : null;
-
-const allSchemas = [
-  ...schemas,
-  ...(breadcrumbListSchema ? [breadcrumbListSchema] : []),
-  ...(navSchema ? [navSchema] : []),
-];
+const schemas = composeSchemaOrg({
+	schemaDocument: schemaModule?.default,
+	currentPath: Astro.url.pathname,
+	siteUrl: Astro.site ?? Astro.url.origin,
+	breadcrumbs,
+	menu: LINKS_MENU,
+	flags: {
+		useSchemaOrg: features?.use_schema_org === true,
+		useBreadcrumbs: features?.use_schema_org_breadcrumbs === true,
+		useNavigation: features?.use_schema_org_navigation === true,
+	},
+});
+const serializedSchemas =
+	schemas.length > 0 ? serializeJsonLd(schemas) : '';
 ---
 
-{allSchemas.length > 0 && (
-  <script type="application/ld+json" set:html={JSON.stringify(allSchemas)} />
+{serializedSchemas && (
+	<script
+		id="schema-org"
+		type="application/ld+json"
+		set:html={serializedSchemas}
+	/>
 )}

--- a/src/integrations/schema-org/schemaOrg.js
+++ b/src/integrations/schema-org/schemaOrg.js
@@ -1,5 +1,4 @@
 const SCHEMA_CONTEXT = 'https://schema.org';
-const NAVIGATION_TYPES = ['ItemList', 'SiteNavigationElement'];
 
 function isPlainObject(value) {
 	return (
@@ -70,7 +69,9 @@ export function normalizeSchemaDocument(value) {
 
 export function containsSchemaType(value, schemaTypes) {
 	const expectedTypes = new Set(
-		Array.isArray(schemaTypes) ? schemaTypes : [schemaTypes],
+		(Array.isArray(schemaTypes) ? schemaTypes : [schemaTypes]).map(
+			normalizeSchemaType,
+		),
 	);
 	const visited = new Set();
 
@@ -92,7 +93,9 @@ export function containsSchemaType(value, schemaTypes) {
 		const types = Array.isArray(candidate['@type'])
 			? candidate['@type']
 			: [candidate['@type']];
-		if (types.some((type) => expectedTypes.has(type))) {
+		if (
+			types.some((type) => expectedTypes.has(normalizeSchemaType(type)))
+		) {
 			return true;
 		}
 
@@ -100,6 +103,18 @@ export function containsSchemaType(value, schemaTypes) {
 	}
 
 	return visit(value);
+}
+
+function normalizeSchemaType(value) {
+	if (typeof value !== 'string') {
+		return value;
+	}
+
+	const absoluteType = value.match(
+		/^https?:\/\/schema\.org\/([^/?#]+)\/?$/i,
+	);
+
+	return absoluteType?.[1] ?? value;
 }
 
 function getBaseUrl(siteUrl) {
@@ -288,7 +303,7 @@ export function composeSchemaOrg({
 
 	if (
 		flags.useNavigation === true &&
-		!containsSchemaType(customSchemas, NAVIGATION_TYPES)
+		!containsSchemaType(customSchemas, 'SiteNavigationElement')
 	) {
 		const navigationSchema = createNavigationSchema({ menu, siteUrl });
 		if (navigationSchema) {

--- a/src/integrations/schema-org/schemaOrg.js
+++ b/src/integrations/schema-org/schemaOrg.js
@@ -1,0 +1,304 @@
+const SCHEMA_CONTEXT = 'https://schema.org';
+const NAVIGATION_TYPES = ['ItemList', 'SiteNavigationElement'];
+
+function isPlainObject(value) {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		!Array.isArray(value)
+	);
+}
+
+function normalizeNodeCollection(value, location) {
+	const nodes = Array.isArray(value) ? value : [value];
+
+	if (nodes.some((node) => !isPlainObject(node))) {
+		throw new TypeError(
+			`Invalid Schema.org v2 document: ${location} must contain JSON-LD objects`,
+		);
+	}
+
+	return nodes;
+}
+
+export function normalizeSchemaDocument(value) {
+	if (value === undefined || value === null) {
+		return { global: [], routes: {} };
+	}
+
+	if (!isPlainObject(value)) {
+		throw new TypeError(
+			'Invalid Schema.org v2 document: root must contain exactly "global" and "routes"',
+		);
+	}
+
+	const keys = Object.keys(value);
+	if (
+		keys.length !== 2 ||
+		!keys.includes('global') ||
+		!keys.includes('routes')
+	) {
+		throw new TypeError(
+			'Invalid Schema.org v2 document: root must contain exactly "global" and "routes"; legacy route maps are not supported',
+		);
+	}
+
+	if (!Array.isArray(value.global)) {
+		throw new TypeError(
+			'Invalid Schema.org v2 document: "global" must be an array',
+		);
+	}
+
+	if (!isPlainObject(value.routes)) {
+		throw new TypeError(
+			'Invalid Schema.org v2 document: "routes" must be an object',
+		);
+	}
+
+	const global = normalizeNodeCollection(value.global, '"global"');
+	const routes = {};
+
+	for (const [route, schemas] of Object.entries(value.routes)) {
+		routes[route] = normalizeNodeCollection(
+			schemas,
+			`"routes"[${JSON.stringify(route)}]`,
+		);
+	}
+
+	return { global, routes };
+}
+
+export function containsSchemaType(value, schemaTypes) {
+	const expectedTypes = new Set(
+		Array.isArray(schemaTypes) ? schemaTypes : [schemaTypes],
+	);
+	const visited = new Set();
+
+	function visit(candidate) {
+		if (
+			candidate === null ||
+			typeof candidate !== 'object' ||
+			visited.has(candidate)
+		) {
+			return false;
+		}
+
+		visited.add(candidate);
+
+		if (Array.isArray(candidate)) {
+			return candidate.some(visit);
+		}
+
+		const types = Array.isArray(candidate['@type'])
+			? candidate['@type']
+			: [candidate['@type']];
+		if (types.some((type) => expectedTypes.has(type))) {
+			return true;
+		}
+
+		return Object.values(candidate).some(visit);
+	}
+
+	return visit(value);
+}
+
+function getBaseUrl(siteUrl) {
+	try {
+		return new URL('/', siteUrl);
+	} catch {
+		throw new TypeError(
+			'Cannot generate Schema.org URLs without a valid site URL',
+		);
+	}
+}
+
+function resolveHttpUrl(value, baseUrl) {
+	if (typeof value !== 'string') {
+		return null;
+	}
+
+	const url = value.trim();
+	if (url === '' || /^\/?#/.test(url)) {
+		return null;
+	}
+
+	try {
+		const resolved = new URL(url, baseUrl);
+		return resolved.protocol === 'http:' || resolved.protocol === 'https:'
+			? resolved.href
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export function createBreadcrumbSchema({
+	breadcrumbs = [],
+	currentPath = '/',
+	siteUrl,
+}) {
+	if (!Array.isArray(breadcrumbs) || breadcrumbs.length === 0) {
+		return null;
+	}
+
+	const baseUrl = getBaseUrl(siteUrl);
+	const items = [
+		{
+			'@type': 'ListItem',
+			position: 1,
+			name: 'Главная',
+			item: new URL('/', baseUrl).href,
+		},
+	];
+
+	for (const [index, breadcrumb] of breadcrumbs.entries()) {
+		if (
+			!isPlainObject(breadcrumb) ||
+			typeof breadcrumb.name !== 'string' ||
+			breadcrumb.name.trim() === ''
+		) {
+			continue;
+		}
+
+		const isFinal = index === breadcrumbs.length - 1;
+		const href =
+			typeof breadcrumb.href === 'string' &&
+			breadcrumb.href.trim() !== ''
+				? breadcrumb.href
+				: isFinal
+					? currentPath
+					: null;
+		const item = resolveHttpUrl(href, baseUrl);
+		if (!item) {
+			continue;
+		}
+
+		items.push({
+			'@type': 'ListItem',
+			position: items.length + 1,
+			name: breadcrumb.name,
+			item,
+		});
+	}
+
+	return items.length > 1
+		? {
+				'@context': SCHEMA_CONTEXT,
+				'@type': 'BreadcrumbList',
+				itemListElement: items,
+			}
+		: null;
+}
+
+function flattenMenuLinks(menu) {
+	const links = [];
+
+	function visit(collection) {
+		if (!Array.isArray(collection)) {
+			return;
+		}
+
+		for (const link of collection) {
+			if (!isPlainObject(link)) {
+				continue;
+			}
+
+			links.push(link);
+
+			if (Array.isArray(link.children)) {
+				visit(link.children);
+			} else if (isPlainObject(link.children)) {
+				for (const childCollection of Object.values(link.children)) {
+					visit(childCollection);
+				}
+			}
+		}
+	}
+
+	visit(menu);
+	return links;
+}
+
+export function createNavigationSchema({ menu = [], siteUrl }) {
+	const baseUrl = getBaseUrl(siteUrl);
+	const itemListElement = [];
+
+	for (const link of flattenMenuLinks(menu)) {
+		if (
+			typeof link.name !== 'string' ||
+			link.name.trim() === ''
+		) {
+			continue;
+		}
+
+		const url = resolveHttpUrl(link.url, baseUrl);
+		if (!url) {
+			continue;
+		}
+
+		itemListElement.push({
+			'@type': 'SiteNavigationElement',
+			position: itemListElement.length + 1,
+			name: link.name,
+			url,
+		});
+	}
+
+	return itemListElement.length > 0
+		? {
+				'@context': SCHEMA_CONTEXT,
+				'@type': 'ItemList',
+				name: 'Главное меню',
+				itemListElement,
+			}
+		: null;
+}
+
+export function composeSchemaOrg({
+	schemaDocument,
+	currentPath = '/',
+	siteUrl,
+	breadcrumbs = [],
+	menu = [],
+	flags = {},
+}) {
+	const schema = normalizeSchemaDocument(schemaDocument);
+	const customSchemas =
+		flags.useSchemaOrg === true
+			? [
+					...schema.global,
+					...(schema.routes[currentPath] ?? []),
+				]
+			: [];
+	const schemas = [...customSchemas];
+
+	if (
+		flags.useBreadcrumbs === true &&
+		!containsSchemaType(customSchemas, 'BreadcrumbList')
+	) {
+		const breadcrumbSchema = createBreadcrumbSchema({
+			breadcrumbs,
+			currentPath,
+			siteUrl,
+		});
+		if (breadcrumbSchema) {
+			schemas.push(breadcrumbSchema);
+		}
+	}
+
+	if (
+		flags.useNavigation === true &&
+		!containsSchemaType(customSchemas, NAVIGATION_TYPES)
+	) {
+		const navigationSchema = createNavigationSchema({ menu, siteUrl });
+		if (navigationSchema) {
+			schemas.push(navigationSchema);
+		}
+	}
+
+	return schemas;
+}
+
+export function serializeJsonLd(value) {
+	return JSON.stringify(value).replace(/</g, '\\u003c');
+}

--- a/src/integrations/schema-org/schemaOrg.test.js
+++ b/src/integrations/schema-org/schemaOrg.test.js
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	composeSchemaOrg,
+	containsSchemaType,
+	createBreadcrumbSchema,
+	createNavigationSchema,
+	normalizeSchemaDocument,
+	serializeJsonLd,
+} from './schemaOrg.js';
+
+const SITE_URL = 'https://dealer.example/';
+
+test('accepts only the strict v2 global/routes root contract', () => {
+	const document = {
+		global: [{ '@type': 'Organization' }],
+		routes: {
+			'/contacts/': { '@type': 'ContactPage' },
+		},
+	};
+
+	assert.deepEqual(normalizeSchemaDocument(document), {
+		global: [{ '@type': 'Organization' }],
+		routes: {
+			'/contacts/': [{ '@type': 'ContactPage' }],
+		},
+	});
+	assert.throws(
+		() =>
+			normalizeSchemaDocument({
+				'/': [{ '@type': 'Organization' }],
+			}),
+		/legacy route maps are not supported/,
+	);
+	assert.throws(
+		() => normalizeSchemaDocument({ global: [], routes: {}, extra: true }),
+		/root must contain exactly/,
+	);
+});
+
+test('allows a missing schema file and keeps all flags false by default', () => {
+	assert.deepEqual(
+		composeSchemaOrg({
+			schemaDocument: undefined,
+			currentPath: '/',
+			siteUrl: SITE_URL,
+			breadcrumbs: [{ name: 'Контакты', href: '' }],
+			menu: [{ name: 'Контакты', url: '/contacts/' }],
+		}),
+		[],
+	);
+});
+
+test('combines global and current route schemas only when custom data is enabled', () => {
+	const schemaDocument = {
+		global: [{ '@type': 'Organization' }],
+		routes: {
+			'/': [{ '@type': 'WebSite' }],
+			'/contacts/': { '@type': 'ContactPage' },
+		},
+	};
+
+	assert.deepEqual(
+		composeSchemaOrg({
+			schemaDocument,
+			currentPath: '/contacts/',
+			siteUrl: SITE_URL,
+			flags: { useSchemaOrg: true },
+		}).map((schema) => schema['@type']),
+		['Organization', 'ContactPage'],
+	);
+	assert.deepEqual(
+		composeSchemaOrg({
+			schemaDocument,
+			currentPath: '/missing/',
+			siteUrl: SITE_URL,
+			flags: { useSchemaOrg: true },
+		}).map((schema) => schema['@type']),
+		['Organization'],
+	);
+});
+
+test('generates breadcrumbs independently and resolves an empty final href', () => {
+	const breadcrumbs = [
+		{ name: 'Модели', href: '/models/' },
+		{ name: 'Модель', href: '' },
+	];
+	const snapshot = structuredClone(breadcrumbs);
+	const schema = createBreadcrumbSchema({
+		breadcrumbs,
+		currentPath: '/models/model/',
+		siteUrl: SITE_URL,
+	});
+
+	assert.deepEqual(breadcrumbs, snapshot);
+	assert.equal(schema['@type'], 'BreadcrumbList');
+	assert.deepEqual(
+		schema.itemListElement.map((item) => item.item),
+		[
+			'https://dealer.example/',
+			'https://dealer.example/models/',
+			'https://dealer.example/models/model/',
+		],
+	);
+	assert.equal(
+		composeSchemaOrg({
+			currentPath: '/models/model/',
+			siteUrl: SITE_URL,
+			breadcrumbs,
+			flags: { useBreadcrumbs: true },
+		})[0]['@type'],
+		'BreadcrumbList',
+	);
+});
+
+test('generates navigation independently and filters unsafe or hash-only links', () => {
+	const schema = createNavigationSchema({
+		siteUrl: SITE_URL,
+		menu: [
+			{ name: 'Модели', url: '/models/' },
+			{ name: 'Якорь', url: '#contacts' },
+			{ name: 'Корневой якорь', url: '/#contacts' },
+			{ name: 'JavaScript', url: 'javascript:alert(1)' },
+			{ name: 'Почта', url: 'mailto:test@example.com' },
+			{ name: 'Телефон', url: 'tel:+70000000000' },
+			{
+				name: 'Внешняя',
+				url: 'https://external.example/path/',
+				children: {
+					brand: [
+						{ name: 'Дочерняя', url: '/models/child/' },
+					],
+				},
+			},
+		],
+	});
+
+	assert.deepEqual(
+		schema.itemListElement.map(({ name, url }) => ({ name, url })),
+		[
+			{ name: 'Модели', url: 'https://dealer.example/models/' },
+			{
+				name: 'Внешняя',
+				url: 'https://external.example/path/',
+			},
+			{
+				name: 'Дочерняя',
+				url: 'https://dealer.example/models/child/',
+			},
+		],
+	);
+	assert.equal(
+		composeSchemaOrg({
+			siteUrl: SITE_URL,
+			menu: [{ name: 'Модели', url: '/models/' }],
+			flags: { useNavigation: true },
+		})[0]['@type'],
+		'ItemList',
+	);
+});
+
+test('recursively detects custom generated-structure types and suppresses duplicates', () => {
+	const schemaDocument = {
+		global: [
+			{
+				'@context': 'https://schema.org',
+				'@graph': [
+					{ '@type': 'BreadcrumbList' },
+					{
+						'@type': 'Thing',
+						nested: {
+							'@type': 'ItemList',
+						},
+					},
+				],
+			},
+		],
+		routes: {},
+	};
+	const schemas = composeSchemaOrg({
+		schemaDocument,
+		currentPath: '/',
+		siteUrl: SITE_URL,
+		breadcrumbs: [{ name: 'Страница', href: '' }],
+		menu: [{ name: 'Модели', url: '/models/' }],
+		flags: {
+			useSchemaOrg: true,
+			useBreadcrumbs: true,
+			useNavigation: true,
+		},
+	});
+
+	assert.equal(schemas.length, 1);
+	assert.equal(containsSchemaType(schemas, 'BreadcrumbList'), true);
+	assert.equal(
+		containsSchemaType(schemas, ['ItemList', 'SiteNavigationElement']),
+		true,
+	);
+});
+
+test('serializes JSON-LD without a literal script-closing sequence', () => {
+	const serialized = serializeJsonLd([
+		{ '@type': 'Thing', name: '</script><script>alert(1)</script>' },
+	]);
+
+	assert.equal(serialized.includes('<'), false);
+	assert.deepEqual(JSON.parse(serialized), [
+		{ '@type': 'Thing', name: '</script><script>alert(1)</script>' },
+	]);
+});

--- a/src/integrations/schema-org/schemaOrg.test.js
+++ b/src/integrations/schema-org/schemaOrg.test.js
@@ -159,20 +159,13 @@ test('generates navigation independently and filters unsafe or hash-only links',
 	);
 });
 
-test('recursively detects custom generated-structure types and suppresses duplicates', () => {
+test('an unrelated custom ItemList does not suppress generated navigation', () => {
 	const schemaDocument = {
 		global: [
 			{
 				'@context': 'https://schema.org',
-				'@graph': [
-					{ '@type': 'BreadcrumbList' },
-					{
-						'@type': 'Thing',
-						nested: {
-							'@type': 'ItemList',
-						},
-					},
-				],
+				'@type': 'ItemList',
+				name: 'Автомобили',
 			},
 		],
 		routes: {},
@@ -181,21 +174,82 @@ test('recursively detects custom generated-structure types and suppresses duplic
 		schemaDocument,
 		currentPath: '/',
 		siteUrl: SITE_URL,
-		breadcrumbs: [{ name: 'Страница', href: '' }],
 		menu: [{ name: 'Модели', url: '/models/' }],
 		flags: {
 			useSchemaOrg: true,
-			useBreadcrumbs: true,
 			useNavigation: true,
+		},
+	});
+
+	assert.equal(schemas.length, 2);
+	assert.equal(schemas[0].name, 'Автомобили');
+	assert.equal(schemas[1].name, 'Главное меню');
+});
+
+test('compact and absolute SiteNavigationElement types suppress generated navigation', () => {
+	for (const type of [
+		'SiteNavigationElement',
+		'https://schema.org/SiteNavigationElement',
+		'http://schema.org/SiteNavigationElement',
+	]) {
+		const schemaDocument = {
+			global: [
+				{
+					'@context': 'https://schema.org',
+					'@graph': [
+						{
+							'@type': 'Thing',
+							nested: { '@type': type },
+						},
+					],
+				},
+			],
+			routes: {},
+		};
+		const schemas = composeSchemaOrg({
+			schemaDocument,
+			currentPath: '/',
+			siteUrl: SITE_URL,
+			menu: [{ name: 'Модели', url: '/models/' }],
+			flags: {
+				useSchemaOrg: true,
+				useNavigation: true,
+			},
+		});
+
+		assert.equal(schemas.length, 1);
+		assert.equal(
+			containsSchemaType(schemas, 'SiteNavigationElement'),
+			true,
+		);
+	}
+});
+
+test('an absolute BreadcrumbList type suppresses generated breadcrumbs', () => {
+	const schemaDocument = {
+		global: [
+			{
+				'@context': 'https://schema.org',
+				'@graph': [
+					{ '@type': 'https://schema.org/BreadcrumbList' },
+				],
+			},
+		],
+		routes: {},
+	};
+	const schemas = composeSchemaOrg({
+		schemaDocument,
+		currentPath: '/contacts/',
+		siteUrl: SITE_URL,
+		breadcrumbs: [{ name: 'Контакты', href: '' }],
+		flags: {
+			useSchemaOrg: true,
+			useBreadcrumbs: true,
 		},
 	});
 
 	assert.equal(schemas.length, 1);
 	assert.equal(containsSchemaType(schemas, 'BreadcrumbList'), true);
-	assert.equal(
-		containsSchemaType(schemas, ['ItemList', 'SiteNavigationElement']),
-		true,
-	);
 });
 
 test('serializes JSON-LD without a literal script-closing sequence', () => {


### PR DESCRIPTION
## Что изменено

- `SchemaOrg.astro` переведён на строгий формат `schema.json` v2: `global` + `routes`.
- Добавлены независимые флаги пользовательской разметки, генерируемого `BreadcrumbList` и навигационного `ItemList`.
- Вложенность хлебных крошек строится по текущему маршруту, а последний пустой `href` разрешается в URL текущей страницы.
- Генерируемое меню фильтрует hash-only и небезопасные ссылки.
- Пользовательский навигационный `ItemList` корректно подавляет его генерацию, но произвольный товарный/контентный `ItemList` больше не считается меню.
- JSON-LD сериализуется безопасно; отсутствие или пустой файл не приводит к выводу разметки.
- Добавлены unit-тесты и проверка обязательного/запрещённого наличия `script#schema-org` в собранном HTML.

## Зачем

Компонент получает единый валидируемый контракт без legacy-ветки и позволяет подключать Schema.org только на выбранных сайтах. Пользовательская разметка SEO-специалиста и автоматически создаваемые breadcrumbs/navigation управляются независимо.

## Проверки

- `pnpm test:schema-org` — 15/15 тестов пройдено.
- Выполнены интеграционные сборки с мигрированными данными сайтов и проверки итогового JSON-LD.
- Известные ошибки отдельных контрольных сборок связаны с отсутствующими content collections (`cars`/`manual`) и не относятся к Schema.org.

## Зависимость

Данные v2 и feature-флаги: https://github.com/alexsab-ru/astro-json/pull/36

Рекомендуемый порядок слияния: сначала `astro-json#36`, затем этот PR.