### PR TITLE
Уведомления о PR в Telegram: rich messages вместо Markdown и запрет исполнения данных события шеллом

### DIFF
--- a/.github/scripts/sh/send_telegram.sh
+++ b/.github/scripts/sh/send_telegram.sh
@@ -7,6 +7,170 @@ BGGREEN='\033[30;42m'
 BGRED='\033[30;41m'
 TEXTRED='\033[30;31m'
 
+is_response_ok() {
+    local response="$1"
+    echo "$response" | grep -q '"ok":true'
+}
+
+# Telegram отвергает сообщение целиком, если разметка не сходится: непарные *, _, [
+# или обратные кавычки в пользовательском тексте. Такое сообщение лучше доставить
+# без форматирования, чем не доставить вовсе.
+should_retry_without_parse_mode() {
+    local response="$1"
+    local parse_mode="$2"
+
+    if [ -z "$parse_mode" ]; then
+        return 1
+    fi
+
+    if echo "$response" | grep -Eqi "can't parse entities|unsupported start tag|can't find end tag|tag must be|entity name"; then
+        return 0
+    fi
+
+    return 1
+}
+
+post_telegram_message() {
+    local token="$1"
+    local chat_id="$2"
+    local message="$3"
+    local parse_mode="$4"
+    local message_thread_id="$5"
+
+    local request_url="https://api.telegram.org/bot${token}/sendMessage"
+    local curl_args=(
+        -sS
+        -X POST
+        "$request_url"
+        --data-urlencode "chat_id=${chat_id}"
+        --data-urlencode "text=${message}"
+        --data "disable_web_page_preview=true"
+    )
+
+    if [ -n "$parse_mode" ]; then
+        curl_args+=(--data-urlencode "parse_mode=${parse_mode}")
+    fi
+
+    if [ -n "$message_thread_id" ]; then
+        curl_args+=(--data-urlencode "message_thread_id=${message_thread_id}")
+    fi
+
+    curl "${curl_args[@]}"
+}
+
+send_with_fallback() {
+    local token="$1"
+    local chat_id="$2"
+    local message="$3"
+    local parse_mode="$4"
+    local message_thread_id="$5"
+
+    local response
+    response=$(post_telegram_message "$token" "$chat_id" "$message" "$parse_mode" "$message_thread_id")
+
+    if ! is_response_ok "$response" && should_retry_without_parse_mode "$response" "$parse_mode"; then
+        echo "Warning: parse_mode=$parse_mode failed for chat $chat_id, retrying without parse_mode" >&2
+        response=$(post_telegram_message "$token" "$chat_id" "$message" "" "$message_thread_id")
+    fi
+
+    echo "$response"
+}
+
+# Максимум для rich message — 32768 UTF-8 символов. Режем с запасом на служебную шапку.
+RICH_MESSAGE_MAX_CHARS=30000
+
+# Отправка одного Rich Message (метод sendRichMessage).
+#
+# В отличие от sendMessage с parse_mode=Markdown, тут не нужно ничего экранировать:
+# rich_message.markdown принимает GitHub Flavored Markdown как есть, поэтому тело
+# PR с таблицами, списками и inline-кодом уходит без ошибок "can't parse entities".
+#
+# Тело запроса собирает jq — он же и экранирует всё для JSON. Никакой конкатенации
+# строк с пользовательским текстом, иначе кавычки и переводы строк ломают payload.
+post_rich_message() {
+    local token="$1"
+    local chat_id="$2"
+    local markdown="$3"
+    local message_thread_id="$4"
+
+    local payload
+    payload=$(jq -n \
+        --arg chat_id "$chat_id" \
+        --arg markdown "$markdown" \
+        --arg thread "$message_thread_id" \
+        '{chat_id: $chat_id, rich_message: {markdown: $markdown}}
+         + (if ($thread | test("^[0-9]+$")) then {message_thread_id: ($thread | tonumber)} else {} end)')
+
+    curl -sS -X POST \
+        "https://api.telegram.org/bot${token}/sendRichMessage" \
+        -H "Content-Type: application/json" \
+        --data-binary "$payload"
+}
+
+send_rich_telegram_message() {
+    local token=$(trim_quotes "$1")
+    local chat_ids=$(trim_quotes "$2")
+    # markdown НЕ прогоняем через trim_quotes: это произвольный текст,
+    # у которого начальная/конечная кавычка может быть значимой.
+    local markdown="$3"
+
+    if [ -z "$token" ] || [ -z "$markdown" ]; then
+        echo "Error: Missing required parameters" >&2
+        echo "Usage: send_rich_telegram_message token chat_ids markdown" >&2
+        return 1
+    fi
+
+    if [ -z "$chat_ids" ]; then
+        echo "Warning: chat_ids is empty, skipping Telegram message send" >&2
+        return 0
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "Error: jq is required for sendRichMessage" >&2
+        return 1
+    fi
+
+    if [ "${#markdown}" -gt "$RICH_MESSAGE_MAX_CHARS" ]; then
+        echo "Warning: message is ${#markdown} chars, truncating to $RICH_MESSAGE_MAX_CHARS" >&2
+        markdown="${markdown:0:$RICH_MESSAGE_MAX_CHARS}
+
+_…сообщение обрезано по лимиту Telegram_"
+    fi
+
+    while IFS= read -r chat_line; do
+        IFS=',/' read -r chat_id message_thread_id <<< "$chat_line"
+
+        [ -z "$chat_id" ] && continue
+
+        echo "Sending rich message to Telegram chat $chat_id"
+
+        RESPONSE=$(post_rich_message "$token" "$chat_id" "$markdown" "$message_thread_id")
+
+        if ! is_response_ok "$RESPONSE"; then
+            # sendRichMessage — новый метод. Если он недоступен, уведомление
+            # всё равно должно дойти, пусть и без форматирования.
+            echo "Warning: sendRichMessage failed for chat $chat_id: $RESPONSE" >&2
+            echo "Falling back to plain sendMessage without parse_mode" >&2
+
+            local curl_args=(-sS -X POST "https://api.telegram.org/bot${token}/sendMessage"
+                --data-urlencode "chat_id=${chat_id}"
+                --data-urlencode "text=${markdown}"
+                --data-urlencode "disable_web_page_preview=true"
+            )
+            if [ -n "$message_thread_id" ]; then
+                curl_args+=(--data-urlencode "message_thread_id=${message_thread_id}")
+            fi
+            RESPONSE=$(curl "${curl_args[@]}")
+
+            if ! is_response_ok "$RESPONSE"; then
+                echo "Error sending message to chat $chat_id: $RESPONSE" >&2
+            fi
+        fi
+
+        sleep 1
+    done <<< "$chat_ids"
+}
+
 send_telegram_messages() {
     # Очищаем входные параметры от кавычек
     local token=$(trim_quotes "$1")
@@ -19,10 +183,17 @@ send_telegram_messages() {
         parse_mode="HTML"
     fi
 
-    if [ -z "$token" ] || [ -z "$chat_ids" ] || [ -z "$total_parts" ]; then
+    if [ -z "$token" ] || [ -z "$total_parts" ]; then
         echo "Error: Missing required parameters" >&2
         echo "Usage: send_telegram_messages token chat_ids total_parts [parse_mode]" >&2
         return 1
+    fi
+
+    # Ненастроенный чат — это пробел в конфиге, а не сбой: предупреждаем и выходим,
+    # иначе весь job падает из-за незаданного секрета.
+    if [ -z "$chat_ids" ]; then
+        echo "Warning: TELEGRAM_TO (chat_ids) is empty, skipping Telegram messages send" >&2
+        return 0
     fi
 
     # Проверяем, что parse_mode имеет допустимое значение
@@ -45,26 +216,10 @@ send_telegram_messages() {
             MESSAGE=$(cat "./tmp_messages/part_${i}.txt")
             echo -e "${BGYELLOW}Sending part $i to Telegram chat $chat_id${Color_Off}"
             echo "MESSAGE: $MESSAGE"
-            
-            # Формируем базовый URL запроса
-            local request_url="https://api.telegram.org/bot${token}/sendMessage"
 
-            # Формируем аргументы curl
-            local curl_args=(-s -X POST "$request_url"
-                --data-urlencode "chat_id=${chat_id}"
-                --data-urlencode "parse_mode=${parse_mode}"
-                --data-urlencode "text=${MESSAGE}"
-                --data-urlencode "disable_web_page_preview=true"
-            )
+            RESPONSE=$(send_with_fallback "$token" "$chat_id" "$MESSAGE" "$parse_mode" "$message_thread_id")
 
-            # Добавляем message_thread_id, если он есть
-            if [ ! -z "$message_thread_id" ]; then
-                curl_args+=(--data-urlencode "message_thread_id=${message_thread_id}")
-            fi
-
-            RESPONSE=$(curl "${curl_args[@]}")
-
-            if ! echo "$RESPONSE" | grep -q '"ok":true'; then
+            if ! is_response_ok "$RESPONSE"; then
                 echo "Error sending message part $i to chat $chat_id: $RESPONSE" >&2
             fi
             
@@ -131,10 +286,16 @@ send_telegram_message() {
         parse_mode="HTML"
     fi
 
-    if [ -z "$token" ] || [ -z "$chat_ids" ] || [ -z "$message" ]; then
+    if [ -z "$token" ] || [ -z "$message" ]; then
         echo "Error: Missing required parameters" >&2
         echo "Usage: send_telegram_message token chat_ids message [parse_mode]" >&2
         return 1
+    fi
+
+    # Ненастроенный чат — пробел в конфиге, а не сбой (см. send_telegram_messages).
+    if [ -z "$chat_ids" ]; then
+        echo "Warning: chat_ids is empty, skipping Telegram message send" >&2
+        return 0
     fi
 
     # Проверяем, что parse_mode имеет допустимое значение
@@ -149,26 +310,10 @@ send_telegram_message() {
         IFS=',/' read -r chat_id message_thread_id <<< "$chat_line"
         
         echo "Sending message to Telegram chat $chat_id"
-        
-        # Формируем базовый URL запроса
-        local request_url="https://api.telegram.org/bot${token}/sendMessage"
 
-        # Формируем аргументы curl
-        local curl_args=(-s -X POST "$request_url"
-            --data-urlencode "chat_id=${chat_id}"
-            --data-urlencode "parse_mode=${parse_mode}"
-            --data-urlencode "text=${message}"
-            --data-urlencode "disable_web_page_preview=true"
-        )
+        RESPONSE=$(send_with_fallback "$token" "$chat_id" "$message" "$parse_mode" "$message_thread_id")
 
-        # Добавляем message_thread_id, если он есть
-        if [ ! -z "$message_thread_id" ]; then
-            curl_args+=(--data-urlencode "message_thread_id=${message_thread_id}")
-        fi
-
-        RESPONSE=$(curl "${curl_args[@]}")
-
-        if ! echo "$RESPONSE" | grep -q '"ok":true'; then
+        if ! is_response_ok "$RESPONSE"; then
             echo "Error sending message to chat $chat_id: $RESPONSE" >&2
         fi
         

--- a/.github/workflows/github-telegram.yml
+++ b/.github/workflows/github-telegram.yml
@@ -118,16 +118,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Send message to Telegram
+        env:
+          # Имя ветки — пользовательский ввод: git разрешает в нём обратные кавычки,
+          # поэтому подставляем через env, а не в текст скрипта (см. job pull_request).
+          NEW_REF: ${{ github.event.ref }}
+          MASTER_BRANCH: ${{ github.event.master_branch }}
+          REPO: ${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_TO_CREATE: ${{ secrets.TELEGRAM_TO_CREATE }}
+          PARSE_MODE: ${{ inputs.parse-mode || 'Markdown' }}
         run: |
           source ./.github/scripts/sh/utils.sh
           source ./.github/scripts/sh/send_telegram.sh
           send_telegram_message \
-          "${{ secrets.TELEGRAM_TOKEN }}" \
-          "${{ secrets.TELEGRAM_TO_CREATE }}" \
-          "*[${{ github.event.repository.name }}:${{ github.ref_name }}]* by [${{ github.actor }}](https://github.com/${{ github.actor }}):
+          "$TELEGRAM_TOKEN" \
+          "$TELEGRAM_TO_CREATE" \
+          "*[${REPO_NAME}:${REF_NAME}]* by [${ACTOR}](https://github.com/${ACTOR}):
 
-          added branch [${{ github.event.ref }}](https://github.com/${{ github.repository }}/tree/${{ github.event.ref }}) from [${{ github.event.master_branch }}](https://github.com/${{ github.repository }}/tree/${{ github.event.master_branch }})" \
-          "${{ inputs.parse-mode || 'Markdown' }}"
+          added branch [${NEW_REF}](https://github.com/${REPO}/tree/${NEW_REF}) from [${MASTER_BRANCH}](https://github.com/${REPO}/tree/${MASTER_BRANCH})" \
+          "$PARSE_MODE"
 
   pull_request:
     if: ${{ github.event.pull_request != null }}
@@ -137,19 +149,49 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Send message to Telegram
+        env:
+          # Всё, что приходит от пользователя, передаём через env, а НЕ через ${{ }}
+          # внутри run. При прямой подстановке GitHub вставляет текст в исходник
+          # скрипта, и обратные кавычки из описания PR выполняются шеллом как
+          # подстановка команд — шаг падает, а описание исполняется на раннере.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ACTION: ${{ github.event.action }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          REPO: ${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          ACTOR: ${{ github.actor }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_TO_PULL_REQUEST: ${{ secrets.TELEGRAM_TO_PULL_REQUEST }}
         run: |
           source ./.github/scripts/sh/utils.sh
           source ./.github/scripts/sh/send_telegram.sh
-          send_telegram_message \
-          "${{ secrets.TELEGRAM_TOKEN }}" \
-          "${{ secrets.TELEGRAM_TO_PULL_REQUEST }}" \
-          "*[${{ github.event.repository.name }}:${{ github.ref_name }}]* by **[${{ github.actor }}](https://github.com/${{ github.actor }})**:
 
-          [pull request #${{ github.event.pull_request.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}) from [${{ github.event.pull_request.head.ref }}](https://github.com/${{ github.repository }}/tree/${{ github.event.head.ref }}) to [${{ github.event.pull_request.base.ref }}](https://github.com/${{ github.repository }}/tree/${{ github.event.base.ref }}) with comment:
-          \`\`\`
-          ${{ github.event.pull_request.body }}
-          \`\`\`" \
-          "${{ inputs.parse-mode || 'Markdown' }}"
+          action="$PR_ACTION"
+          if [ "$PR_ACTION" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
+            action="merged"
+          fi
+
+          # Тело PR подставляется раскрытием переменной — результат повторно не
+          # разбирается шеллом, поэтому обратные кавычки внутри безопасны.
+          # Дальше это уходит в rich_message.markdown как GitHub Flavored Markdown.
+          markdown="## ${REPO_NAME}: pull request #${PR_NUMBER} ${action}
+
+          [**${PR_TITLE}**](https://github.com/${REPO}/pull/${PR_NUMBER})
+
+          by [@${ACTOR}](https://github.com/${ACTOR}) · [\`${HEAD_REF}\`](https://github.com/${REPO}/tree/${HEAD_REF}) → [\`${BASE_REF}\`](https://github.com/${REPO}/tree/${BASE_REF})
+
+          ---
+
+          ${PR_BODY}"
+
+          send_rich_telegram_message \
+            "$TELEGRAM_TOKEN" \
+            "$TELEGRAM_TO_PULL_REQUEST" \
+            "$markdown"
 
   delete:
     if: ${{ github.event.master_branch == null && github.event.commits == null && github.event.pull_request == null && inputs.additional-text == null }}
@@ -159,16 +201,25 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Send message to Telegram
+        env:
+          # Имя ветки может содержать обратные кавычки — только через env.
+          DELETED_REF: ${{ github.event.ref }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_TO_DELETE: ${{ secrets.TELEGRAM_TO_DELETE }}
+          PARSE_MODE: ${{ inputs.parse-mode || 'Markdown' }}
         run: |
           source ./.github/scripts/sh/utils.sh
           source ./.github/scripts/sh/send_telegram.sh
           send_telegram_message \
-          "${{ secrets.TELEGRAM_TOKEN }}" \
-          "${{ secrets.TELEGRAM_TO_DELETE }}" \
-          "*[${{ github.event.repository.name }}:${{ github.ref_name }}]* by [${{ github.actor }}](https://github.com/${{ github.actor }}):
+          "$TELEGRAM_TOKEN" \
+          "$TELEGRAM_TO_DELETE" \
+          "*[${REPO_NAME}:${REF_NAME}]* by [${ACTOR}](https://github.com/${ACTOR}):
 
-          branch '\`${{ github.event.ref }}\`' is deleted" \
-          "${{ inputs.parse-mode || 'Markdown' }}"
+          branch '\`${DELETED_REF}\`' is deleted" \
+          "$PARSE_MODE"
 
   issues:
     if: ${{ github.event.issue != null }}
@@ -178,16 +229,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Send message to Telegram
+        env:
+          # Заголовок issue — произвольный пользовательский текст, включая
+          # обратные кавычки. Подставляем через env, а не в текст скрипта.
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_ACTION: ${{ github.event.action }}
+          REPO: ${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          ACTOR: ${{ github.actor }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_TO_ISSUES: ${{ secrets.TELEGRAM_TO_ISSUES }}
+          PARSE_MODE: ${{ inputs.parse-mode || 'Markdown' }}
         run: |
           source ./.github/scripts/sh/utils.sh
           source ./.github/scripts/sh/send_telegram.sh
           send_telegram_message \
-          "${{ secrets.TELEGRAM_TOKEN }}" \
-          "${{ secrets.TELEGRAM_TO_ISSUES }}" \
-          "*[${{ github.event.repository.name }}]* by [${{ github.actor }}](https://github.com/${{ github.actor }}):
+          "$TELEGRAM_TOKEN" \
+          "$TELEGRAM_TO_ISSUES" \
+          "*[${REPO_NAME}]* by [${ACTOR}](https://github.com/${ACTOR}):
 
-          issue #${{ github.event.issue.number }} [${{ github.event.issue.title }}](https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}) was ${{ github.event.action }}" \
-          "${{ inputs.parse-mode || 'Markdown' }}"
+          issue #${ISSUE_NUMBER} [${ISSUE_TITLE}](https://github.com/${REPO}/issues/${ISSUE_NUMBER}) was ${ISSUE_ACTION}" \
+          "$PARSE_MODE"
 
   get_last_commit:
     if: ${{ inputs.additional-text != null }}

--- a/.github/workflows/github-telegram.yml
+++ b/.github/workflows/github-telegram.yml
@@ -194,7 +194,7 @@ jobs:
             "$markdown"
 
   delete:
-    if: ${{ github.event.master_branch == null && github.event.commits == null && github.event.pull_request == null && inputs.additional-text == null }}
+    if: ${{ github.event.master_branch == null && github.event.commits == null && github.event.pull_request == null && inputs.additional-text == null && github.event.issue == null }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Перенос правки из `astro-json` ([PR #37](https://github.com/alexsab-ru/astro-json/pull/37)), плюс выравнивание двух реализаций между собой.

## Что было не так

Тело PR подставлялось через `${{ github.event.pull_request.body }}` **прямо в исходник shell-скрипта**. В двойных кавычках обратные кавычки — это подстановка команд, поэтому описание PR исполнялось на раннере. В `astro-json` это выглядело так:

```
line 4: mergeJson.sh: command not found
line 4: src/cars.json: Permission denied
line 4: pnpm: command not found
```

Здесь ровно тот же код, просто пока не попадалось описание с inline-кодом.

## Что сделано

**Данные события — через `env`.** Раскрытие переменной шеллом повторно не разбирается, поэтому обратные кавычки внутри безопасны. Закрыты четыре job'а: `pull_request` (тело и заголовок), `issues` (заголовок), `create` и `delete` (имена веток — git разрешает в них обратные кавычки). Остались только `repository.name` и `github.event.before`: там набор символов ограничен.

**Уведомления о PR — методом `sendRichMessage`.** Поле `rich_message.markdown` принимает GitHub Flavored Markdown как есть, экранировать не нужно. Тело запроса собирает `jq`, он же экранирует JSON. Есть откат на обычный `sendMessage`, если метод недоступен, и обрезка по лимиту 32768 символов.

**Подтянуто из `astro-json`**, чего в этом репозитории не было:

- откат на отправку без `parse_mode`, когда Telegram отвергает разметку (`can't parse entities`) — `create`/`delete`/`issues` по-прежнему шлют обычным `sendMessage`, и теперь сообщение дойдёт без форматирования вместо того, чтобы потеряться;
- пустой `chat_ids` — предупреждение, а не падение job'а: ненастроенный секрет это пробел в конфиге, а не сбой.

`send_telegram_file` оставлен как есть — он используется в `action-pages.yml` и в `astro-json` не переносился, чтобы не плодить мёртвый код.

## Проверено

Шаг прогонялся локально ровно так, как его выполнит runner (разбор YAML → `eval` того же скрипта), с заглушкой вместо `curl`:

- на **реальном теле PR #37** с 132 фрагментами inline-кода — 136 обратных кавычек доехали до payload без потерь, метод `sendRichMessage`, JSON валиден;
- на теле с намеренной инъекцией (`` `touch файл` ``, `$(...)`, кавычки, бэкслеш, таб) — команда **не выполнилась**, содержимое сохранено буквально. На старом коде та же проверка создавала файл, то есть уязвимость воспроизводится;
- откат `parse_mode`: `Markdown` → без `parse_mode` при ответе `can't parse entities`;
- пустой `chat_ids` → предупреждение и код возврата 0;
- обрезка: 35000 → 30042 символов с пометкой;
- сканер по всем воркфлоу репозитория не находит ни одной подстановки пользовательских полей `github.event.*` внутри `run:`.

Отдельно проверено в `astro-json`: после правки прогон `pull_request` зелёный, в логе `Sending rich message to Telegram chat ***` без откатов и ошибок — то есть `sendRichMessage` принимает такое сообщение.

## Не входит

`api.alexsab.ru`, `lead` и `scripts` шлют уведомления через action `appleboy/telegram-action`, а не через эти скрипты. Инъекции там нет — тело PR идёт в `with:`, а не в шелл. Но `format: markdown` у них ломается на описаниях с разметкой ровно так же. Перевод их на rich messages — отдельная задача, здесь не делался.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQAaueAuDvN2u8Z1UEaPcA