### PR TITLE
Report real page-start time to counters, complete the VK pixel, guard the domain redirect

### DIFF
--- a/src/integrations/scripts/ScriptsBodyBeginPlatform.astro
+++ b/src/integrations/scripts/ScriptsBodyBeginPlatform.astro
@@ -2,7 +2,9 @@
 import GTM from '@/integrations/scripts/providers/GoogleTagManagerBody.astro';
 import METRIKA_DEV from '@/integrations/scripts/providers/YandexMetrikaDevelopmentBody.astro';
 import METRIKA from '@/integrations/scripts/providers/YandexMetrikaBody.astro';
+import TOP_MAIL_RU from '@/integrations/scripts/providers/TopMailRuPixelBody.astro';
 ---
 <GTM />
 <METRIKA_DEV />
 <METRIKA />
+<TOP_MAIL_RU />

--- a/src/integrations/scripts/ScriptsHeadPlatform.astro
+++ b/src/integrations/scripts/ScriptsHeadPlatform.astro
@@ -10,6 +10,7 @@ const dealer_params = JSON.stringify({
     ...(grecaptcha_action && { grecaptcha_action })
 });
 import { cleanScriptsData } from '@/integrations/scripts/providers/clean-scripts-data';
+import PageStart from '@/integrations/scripts/providers/PageStart.astro';
 import GTM from '@/integrations/scripts/providers/GoogleTagManager.astro';
 import METRIKA_DEV from '@/integrations/scripts/providers/YandexMetrikaDevelopment.astro';
 import METRIKA from '@/integrations/scripts/providers/YandexMetrika.astro';
@@ -27,6 +28,7 @@ import DWELL from '@/integrations/scripts/providers/DwellBeacon.astro';
 
 const cleanedScripts = cleanScriptsData(scripts_json);
 ---
+<PageStart />
 <script id="scripts_json" type="application/ld+json" set:html={cleanedScripts}/>
 <script id="settings_json" type="application/ld+json" set:html={dealer_params}/>
 <GTM />

--- a/src/integrations/scripts/providers/GoogleAnalytics.astro
+++ b/src/integrations/scripts/providers/GoogleAnalytics.astro
@@ -14,7 +14,7 @@ function runGA4(scripts_json_ga4) {
         document.head.appendChild(script);
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+        gtag('js', new Date(window.__pageStart || Date.now()));
         gtag('config', ga.id);
     });
 }

--- a/src/integrations/scripts/providers/GoogleTagManager.astro
+++ b/src/integrations/scripts/providers/GoogleTagManager.astro
@@ -8,7 +8,7 @@ const isProd = import.meta.env.PROD;
 function runGTM(scripts_json_gtm) {
     // console.log("runGTM", scripts_json_gtm);
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    (w.__pageStart || Date.now()),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer',scripts_json_gtm);

--- a/src/integrations/scripts/providers/PageStart.astro
+++ b/src/integrations/scripts/providers/PageStart.astro
@@ -1,0 +1,20 @@
+---
+// Единая точка отсчёта загрузки страницы для всех счётчиков.
+// Аналитика стартует отложенно (LoadScripts.astro: первое взаимодействие или таймер 3 с),
+// поэтому Date.now() в момент запуска счётчика даёт время на секунды позже реальной загрузки
+// и ломает метрики скорости в Метрике / GTM / GA4 / Top.Mail.Ru.
+// Берём navigationStart браузера — он не зависит от того, когда мы запустили счётчик.
+// is:inline — скрипт должен выполниться сразу при парсинге <head>, без бандлинга и defer.
+---
+<script is:inline>
+window.__pageStart = (function () {
+    try {
+        var p = window.performance;
+        if (p) {
+            if (typeof p.timeOrigin === 'number' && p.timeOrigin > 0) return Math.round(p.timeOrigin);
+            if (p.timing && p.timing.navigationStart) return p.timing.navigationStart;
+        }
+    } catch (e) {}
+    return Date.now();
+})();
+</script>

--- a/src/integrations/scripts/providers/PageStart.astro
+++ b/src/integrations/scripts/providers/PageStart.astro
@@ -6,15 +6,4 @@
 // Берём navigationStart браузера — он не зависит от того, когда мы запустили счётчик.
 // is:inline — скрипт должен выполниться сразу при парсинге <head>, без бандлинга и defer.
 ---
-<script is:inline>
-window.__pageStart = (function () {
-    try {
-        var p = window.performance;
-        if (p) {
-            if (typeof p.timeOrigin === 'number' && p.timeOrigin > 0) return Math.round(p.timeOrigin);
-            if (p.timing && p.timing.navigationStart) return p.timing.navigationStart;
-        }
-    } catch (e) {}
-    return Date.now();
-})();
-</script>
+<script is:inline> window.__pageStart = (function () { try { var p = window.performance; if (p) { if (typeof p.timeOrigin === 'number' && p.timeOrigin > 0) return Math.round(p.timeOrigin); if (p.timing && p.timing.navigationStart) return p.timing.navigationStart; } } catch (e) {} return Date.now(); })(); </script>

--- a/src/integrations/scripts/providers/TopMailRuPixel.astro
+++ b/src/integrations/scripts/providers/TopMailRuPixel.astro
@@ -3,14 +3,15 @@ import scripts_json from '@/data/site/scripts.json';
 const isModeProd = import.meta.env.MODE === 'production';
 const isProd = import.meta.env.PROD;
 ---
-{ isProd && scripts_json['top.mail.ru'] && scripts_json['top.mail.ru'].value.length > 0 && scripts_json['top.mail.ru'].value[0].id != "" && (
+{ isProd && scripts_json['top.mail.ru'] && scripts_json['top.mail.ru'].value.length > 0 && String(scripts_json['top.mail.ru'].value[0].id ?? '').trim() !== "" && (
 <script>
 function runTOP_MAIL_RU(top_mail_ru) {
     // console.log("runTOP_MAIL_RU", top_mail_ru);
     top_mail_ru.forEach(mail => {
-        if (mail.id && mail.id.trim() !== "") {
+        const id = String(mail?.id ?? '').trim();
+        if (id !== "") {
             var script = document.createElement('script');
-            script.innerHTML = `var _tmr = window._tmr || (window._tmr = []); _tmr.push({id: "${mail.id}", type: "pageView", start: (new Date()).getTime()}); (function (d, w, id) { if (d.getElementById(id)) return; var ts = d.createElement("script"); ts.type = "text/javascript"; ts.async = true; ts.id = id; ts.src = "https://top-fwz1.mail.ru/js/code.js"; var f = function () {var s = d.getElementsByTagName("script")[0]; s.parentNode.insertBefore(ts, s);}; if (w.opera == "[object Opera]") { d.addEventListener("DOMContentLoaded", f, false); } else { f(); } })(document, window, "topmailru-code");`;
+            script.innerHTML = `var _tmr = window._tmr || (window._tmr = []); _tmr.push({id: "${id}", type: "pageView", start: (window.__pageStart || Date.now())}); (function (d, w, id) { if (d.getElementById(id)) return; var ts = d.createElement("script"); ts.type = "text/javascript"; ts.async = true; ts.id = id; ts.src = "https://top-fwz1.mail.ru/js/code.js"; var f = function () {var s = d.getElementsByTagName("script")[0]; s.parentNode.insertBefore(ts, s);}; if (w.opera == "[object Opera]") { d.addEventListener("DOMContentLoaded", f, false); } else { f(); } })(document, window, "tmr-code");`;
             document.head.appendChild(script);
         }
     });

--- a/src/integrations/scripts/providers/TopMailRuPixelBody.astro
+++ b/src/integrations/scripts/providers/TopMailRuPixelBody.astro
@@ -1,0 +1,11 @@
+---
+import scripts_json from '@/data/site/scripts.json';
+const isModeProd = import.meta.env.MODE === 'production';
+const isProd = import.meta.env.PROD;
+const topMailRuIds = (scripts_json['top.mail.ru']?.value ?? [])
+    .map(mail => String(mail?.id ?? '').trim())
+    .filter(id => id !== '');
+---
+{ isProd && topMailRuIds.map(id => (
+    <noscript><div><img src={`https://top-fwz1.mail.ru/counter?id=${id};js=na`} style="position:absolute;left:-9999px;" alt="Top.Mail.Ru" /></div></noscript>
+)) }

--- a/src/integrations/scripts/providers/VkRetargetingPixel.astro
+++ b/src/integrations/scripts/providers/VkRetargetingPixel.astro
@@ -3,14 +3,15 @@ import scripts_json from '@/data/site/scripts.json';
 const isModeProd = import.meta.env.MODE === 'production';
 const isProd = import.meta.env.PROD;
 ---
-{ isProd && scripts_json['vk-rtrg'] && scripts_json['vk-rtrg'].value.length > 0 && scripts_json['vk-rtrg'].value[0].id != "" && (
+{ isProd && scripts_json['vk-rtrg'] && scripts_json['vk-rtrg'].value.length > 0 && String(scripts_json['vk-rtrg'].value[0].id ?? '').trim() !== "" && (
 <script>
 function runVK_RTRG(vk_rtrg) {
     // console.log("runVK_RTRG", vk_rtrg);
     vk_rtrg.forEach(vk => {
-        if (vk.id && vk.id.trim() !== "") {
+        const id = String(vk?.id ?? '').trim();
+        if (id !== "") {
             var script = document.createElement('script');
-            script.innerHTML = `!function(){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://vk.ru/js/api/openapi.js?169",t.onload=function(){VK.Retargeting.Init("${vk.id}"),VK.Retargeting.Hit()},document.head.appendChild(t)}();`;
+            script.innerHTML = `!function(){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://vk.ru/js/api/openapi.js?169",t.onload=function(){VK.Retargeting.Init("${id}"),VK.Retargeting.Hit()},document.head.appendChild(t)}();`;
             document.head.appendChild(script);
         }
     });

--- a/src/integrations/scripts/providers/YandexMetrika.astro
+++ b/src/integrations/scripts/providers/YandexMetrika.astro
@@ -8,7 +8,7 @@ const isProd = import.meta.env.PROD;
 function runMETRIKA(scripts_json_metrika) {
     // console.log("runMETRIKA", scripts_json_metrika);
     let ymFunc = function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-    m[i].l=1*new Date();
+    m[i].l=m.__pageStart||1*new Date();
     for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
     k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)}
 

--- a/src/integrations/scripts/providers/YandexMetrikaDevelopment.astro
+++ b/src/integrations/scripts/providers/YandexMetrikaDevelopment.astro
@@ -8,7 +8,7 @@ const isProd = import.meta.env.PROD;
 function runMETRIKA(scripts_json_metrika) {
     // console.log("runMETRIKA_DEV", scripts_json_metrika);
     let ymFunc = function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-    m[i].l=1*new Date();
+    m[i].l=m.__pageStart||1*new Date();
     for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
     k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)}
 

--- a/src/site-shell/strip-empty-query/StripEmptyQuery.astro
+++ b/src/site-shell/strip-empty-query/StripEmptyQuery.astro
@@ -1,6 +1,8 @@
 ---
 import scripts_json from '@/data/site/scripts.json';
-const site = scripts_json.site;
+const site = String(scripts_json.site ?? '').trim();
 ---
-<script data-remove-script-after-work="check_empty_query"> if (location.href.split("#")[0].slice(-1) === '?') { const target = location.pathname + location.hash; location.replace(target); } else { const script = document.querySelector('script[data-remove-script-after-work="check_empty_query"]'); if (script) { script.remove(); } } </script>
-<script define:vars={{ site }} data-remove-script-after-work="domain_redirect"> if (location.host.startsWith('alexsab')) { location.href = "https://" + site; } else { const script = document.querySelector('script[data-remove-script-after-work="domain_redirect"]'); if (script) { script.remove(); } } </script>
+<script is:inline> if (location.href.split("#")[0].slice(-1) === '?') { location.replace(location.pathname + location.hash); } </script>
+{ site !== "" && (
+<script is:inline define:vars={{ site }}> if (location.host.startsWith('alexsab')) { location.href = "https://" + site; } </script>
+) }


### PR DESCRIPTION
Возникло из сверки нашего подключения Top.Mail.Ru с базовым кодом пикселя из кабинета VK.

## Реальное время загрузки страницы для всех счётчиков

Аналитика стартует отложенно (`LoadScripts.astro`: первое взаимодействие или таймер 3 с), а каждый счётчик брал отметку времени загрузки через `Date.now()` в момент своего запуска. В результате Метрика, GTM, GA4 и Top.Mail.Ru видели время загрузки на секунды позже реального.

Новый `PageStart.astro` рендерится первым в `<head>` с `is:inline` (без бандлинга и defer) и кладёт в `window.__pageStart` момент начала навигации: `performance.timeOrigin` → `performance.timing.navigationStart` → `Date.now()`. Это значение не зависит от того, когда мы запустили счётчик. Все четыре счётчика теперь читают его вместо собственной отметки; в каждом оставлен фолбэк `|| Date.now()`.

## Top.Mail.Ru приведён к базовому коду VK

- **Добавлен `<noscript>`-пиксель** (`TopMailRuPixelBody.astro`, подключён в `ScriptsBodyBeginPlatform` рядом с фолбэками GTM и Метрики). Раньше визиты без JS не считались вообще.
- **`topmailru-code` → канонический `tmr-code`** для id вставляемого тега. Если второй счётчик попадёт на страницу «родным» кодом (GTM, партнёрский виджет), он теперь наткнётся на наш guard от дублей, а не загрузит `code.js` второй раз.
- **`String()` вокруг id** в `TopMailRuPixel` и `VkRetargetingPixel`, и в build-time-гейте, и в рантайме. Числовой id в `scripts.json` (как уже есть у `metrika`) ронял `id.trim()`, а `TypeError` молча съедался `try/catch` в `LoadScripts` — счётчик просто оставался мёртвым без следов в консоли.

`pid` сознательно по-прежнему не отправляется: это идентификатор залогиненного пользователя на стороне сайта, а на дилерских сайтах авторизации нет. Отправка литерала `"USER_ID"` из базового кода склеила бы всех посетителей в одного человека.

## StripEmptyQuery

- Скрипт редиректа на боевой домен рендерился безусловно. При пустом `scripts_json.site` посетителей с alexsab-хостов увело бы на голый `https://`. Проверка вынесена вокруг самого тега — как у счётчиков в `integrations/scripts/providers`.
- Оба скрипта удаляли собственный `<script>` после выполнения. Мёртвый код: к этому моменту скрипт уже отработал, удаление узла ничего не отменяет, и стояло оно в `else`-ветке — там, где скрипт и так ничего не делал. Вместе с ним ушли атрибуты `data-remove-script-after-work`, это 383 байта на страницу до сжатия.

Важно: удаление стало безопасным только потому, что на обоих тегах теперь есть `is:inline`. Раньше именно кастомный атрибут удерживал первый скрипт от попадания в бандл — без него он стал бы `type="module"`, то есть deferred, и редирект срабатывал бы уже после отрисовки страницы.

## Что осталось

Цели в Top.Mail.Ru по-прежнему не передаются — уходит только `pageView`, поэтому кампании в VK Ads нельзя оптимизировать по заявкам. Вынесено в #121.

## Проверка

`pnpm build` — 296 страниц, ошибок нет. В `dist/index.html` проверено глазами: `<noscript>`-пиксель на месте, `start: (window.__pageStart || Date.now())` в Top.Mail.Ru, `.l=n.__pageStart||1*new Date` в Метрике, оба скрипта StripEmptyQuery инлайн и первыми в `<head>`, `data-remove-script-after-work` в выводе не осталось.

GTM и GA4 на тестовом домене (`berezniki.expertmotors-tenet.ru`) отключены пустым конфигом, поэтому их фрагменты в этой сборке не рендерились — правки там однотипные с остальными, но в собранном виде я их не видел.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
