### PR TITLE
fix(forms): clear stale phone validity

### DIFF
--- a/docs/calltouch-regression-test-plan.md
+++ b/docs/calltouch-regression-test-plan.md
@@ -203,7 +203,7 @@ Changan, но открытый draft PR сам по себе не означае
 
 | Сценарий | Callback API | Calltouch Lead API | PHP и уведомления | Ожидаемый результат |
 | --- | --- | --- | --- | --- |
-| Невалидный телефон | нет | нет | нет | Клиент показывает ошибку; сетевых запросов отправки нет |
+| Невалидный телефон | нет | нет | нет | Клиент показывает ошибку; сетевых запросов отправки нет. После исправления номера в той же форме повторный submit должен стать доступен без перезагрузки страницы |
 | Валидная фикстура, client success | один client | нет | `events.calltouch_callback_created` | Ровно один callback, PHP получает `client_success` |
 | Spam-like фикстура, client success | callback может быть уже принят | нет | без дилерских уведомлений | PHP отвечает `attention=true`, spam не восстанавливает получателей |
 | `79000000000`, client success | один client | нет | только callback test/webmaster Telegram | Нет email, MAX и дилерского Telegram |
@@ -651,6 +651,8 @@ session ID.
 - [ ] Проверен server fallback без session ID и с прямыми UTM.
 - [ ] Проверен business rejection без server retry.
 - [ ] Проверены invalid, spam-like и test-phone маршруты.
+- [ ] После невалидного submit телефон исправлен в той же форме; ошибка снята,
+      повторный submit проходит без перезагрузки страницы.
 - [ ] Проверены Telegram, MAX и email overrides.
 - [ ] В журнале нет пары «callback + Lead API» для одной отправки.
 - [ ] Каждый `server_success` содержит `callback_request_id` и подтверждён в

--- a/src/js/modules/FormsValidation.js
+++ b/src/js/modules/FormsValidation.js
@@ -142,6 +142,12 @@ export default class FormsValidation {
                         errorField._inputHandler && element.removeEventListener(eventType, errorField._inputHandler);
                         // Добавляем новый обработчик: при изменении/вводе скрываем сообщение
                         const handler = () => {
+                            // Телефонная ошибка выставляется через setCustomValidity().
+                            // Сбрасываем её сразу при редактировании, иначе браузер
+                            // заблокирует следующий submit до повторного вызова validate().
+                            if (element.type === 'tel') {
+                                element.setCustomValidity('');
+                            }
                             errorField.classList.add('hidden');
                             element.removeEventListener(eventType, handler);
                             errorField._inputHandler = null;

--- a/src/js/modules/FormsValidation.test.mjs
+++ b/src/js/modules/FormsValidation.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const sourceUrl = new URL('./FormsValidation.js', import.meta.url);
+const source = readFileSync(sourceUrl, 'utf8').replace(
+	'import { phoneChecker } from "@alexsab-ru/scripts";',
+	`const phoneChecker = (phone) => phone.value === '+7 927 749-94-77';`
+);
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`;
+const { default: FormsValidation } = await import(moduleUrl);
+
+class FakeClassList {
+	constructor(...classes) {
+		this.classes = new Set(classes);
+	}
+
+	add(className) {
+		this.classes.add(className);
+	}
+
+	remove(className) {
+		this.classes.delete(className);
+	}
+
+	contains(className) {
+		return this.classes.has(className);
+	}
+}
+
+class FakePhoneInput extends EventTarget {
+	constructor(errorField) {
+		super();
+		this.disabled = false;
+		this.type = 'tel';
+		this.required = true;
+		this.offsetParent = {};
+		this.value = '+7 927';
+		this.minLength = -1;
+		this.maxLength = -1;
+		this.name = 'phone';
+		this.parentElement = {
+			querySelector: () => errorField,
+		};
+		this.customValidationMessage = '';
+	}
+
+	closest() {
+		return null;
+	}
+
+	setCustomValidity(message) {
+		this.customValidationMessage = message;
+	}
+
+	get validationMessage() {
+		return this.customValidationMessage;
+	}
+
+	get validity() {
+		return {
+			valueMissing: false,
+			patternMismatch: false,
+			tooShort: false,
+			tooLong: false,
+			customError: this.customValidationMessage !== '',
+		};
+	}
+
+	scrollIntoView() {}
+}
+
+const createFixture = () => {
+	const errorField = {
+		innerText: '',
+		classList: new FakeClassList('hidden'),
+		_inputHandler: null,
+	};
+	const phone = new FakePhoneInput(errorField);
+	const form = {
+		elements: [phone],
+		querySelector: () => errorField,
+		querySelectorAll: () => [],
+	};
+
+	return {
+		errorField,
+		phone,
+		validation: new FormsValidation(form),
+	};
+};
+
+test('corrected phone can be validated after an invalid submit attempt', () => {
+	const { errorField, phone, validation } = createFixture();
+
+	validation.validate();
+	assert.equal(validation.isValid, false);
+	assert.equal(phone.validity.customError, true);
+	assert.equal(errorField.classList.contains('hidden'), false);
+
+	phone.value = '+7 927 749-94-77';
+	phone.dispatchEvent(new Event('input'));
+
+	assert.equal(phone.validity.customError, false);
+	assert.equal(errorField.classList.contains('hidden'), true);
+	assert.equal(errorField._inputHandler, null);
+
+	validation.validate();
+	assert.equal(validation.isValid, true);
+	assert.equal(phone.validity.customError, false);
+});
+
+test('editing clears the stale browser error but validation still rejects an invalid phone', () => {
+	const { phone, validation } = createFixture();
+
+	validation.validate();
+	phone.value = '+7 928';
+	phone.dispatchEvent(new Event('input'));
+	assert.equal(phone.validity.customError, false);
+
+	validation.validate();
+	assert.equal(validation.isValid, false);
+	assert.equal(phone.validity.customError, true);
+});


### PR DESCRIPTION
## Summary
- clear the phone input customValidity state on the first edit after a validation error
- keep normal phone-format validation on the next submit
- add regression coverage for correcting the phone in the same form without reloading
- document the scenario in the Calltouch regression test plan

## Root cause
FormsValidation hid the visible error after an input event but retained the browser customError flag. Native constraint validation then blocked the next submit before FormsValidation.validate() could clear it.

## Tests
- node --test FormsValidation, calltouchLeadDecision, devHost and features: 10 passed
- callback source contract: passed
- DOMAIN=dev.alexsab.ru pnpm verify: 2349 pages
- git diff --check