### PR TITLE
fix: redirect technical hosting URLs

### DIFF
--- a/src/site-shell/strip-empty-query/StripEmptyQuery.astro
+++ b/src/site-shell/strip-empty-query/StripEmptyQuery.astro
@@ -1,8 +1,53 @@
 ---
 import scripts_json from '@/data/site/scripts.json';
-const site = String(scripts_json.site ?? '').trim();
+const rawSite = String(scripts_json.site ?? '').trim();
+const repo = String(scripts_json.repo ?? '').trim();
+
+const siteHost = (() => {
+	if (!rawSite) return '';
+
+	try {
+		const siteUrl = rawSite.includes('://') ? rawSite : `https://${rawSite}`;
+		return new URL(siteUrl).hostname.toLowerCase();
+	} catch {
+		return '';
+	}
+})();
 ---
-<script is:inline> if (location.href.split("#")[0].slice(-1) === '?') { location.replace(location.pathname + location.hash); } </script>
-{ site !== "" && (
-<script is:inline define:vars={{ site }}> if (location.host.startsWith('alexsab')) { location.href = "https://" + site; } </script>
-) }
+
+<script is:inline define:vars={{ siteHost, repo }}>
+	const hasEmptyQuery = location.href.split('#')[0].endsWith('?');
+	let canonicalPath = null;
+
+	if (siteHost) {
+		const githubPagesPrefix = repo ? `/${repo}` : '';
+		const yandexBucketPrefix = `/${siteHost}`;
+
+		if (
+			location.hostname.endsWith('.github.io') &&
+			githubPagesPrefix &&
+			(location.pathname === githubPagesPrefix ||
+				location.pathname.startsWith(`${githubPagesPrefix}/`))
+		) {
+			canonicalPath = location.pathname.slice(githubPagesPrefix.length) || '/';
+		} else if (location.hostname === `${siteHost}.website.yandexcloud.net`) {
+			canonicalPath = location.pathname;
+		} else if (
+			location.hostname === 'website.yandexcloud.net' &&
+			(location.pathname === yandexBucketPrefix ||
+				location.pathname.startsWith(`${yandexBucketPrefix}/`))
+		) {
+			canonicalPath = location.pathname.slice(yandexBucketPrefix.length) || '/';
+		}
+	}
+
+	if (canonicalPath !== null) {
+		const canonicalUrl = new URL(`https://${siteHost}`);
+		canonicalUrl.pathname = canonicalPath;
+		canonicalUrl.search = location.search;
+		canonicalUrl.hash = location.hash;
+		location.replace(canonicalUrl.href);
+	} else if (hasEmptyQuery) {
+		location.replace(location.pathname + location.hash);
+	}
+</script>


### PR DESCRIPTION
## Что изменено

- технические URL GitHub Pages перенаправляются на основной домен с сохранением пути, query и hash
- добавлены оба варианта Yandex Object Storage: `<bucket>.website.yandexcloud.net` и `website.yandexcloud.net/<bucket>`
- используется `location.replace()` вместо `location.href`
- условия ограничены точным repo/bucket path, canonical host не затрагивается
- сохранено удаление одиночного пустого `?`

## Причина

Прежняя проверка `location.host.startsWith('alexsab')` была слишком широкой и при редиректе теряла route, query и hash. Технические URL Yandex оставались доступны без редиректа.

## Проверки

- `git diff --check`
- `pnpm build` для `sales-autoholding-turgenevskiy.ru`
- исполнение собранного inline-script в матрице из 7 URL-сценариев
